### PR TITLE
Rational dimension exponents and other SI units

### DIFF
--- a/mesitype.h
+++ b/mesitype.h
@@ -128,31 +128,33 @@ namespace Mesi {
 		std::ratio<t_mol_n, t_mol_d>::num, std::ratio<t_mol_n, t_mol_d>::den,
 		std::ratio<t_cd_n, t_cd_d>::num, std::ratio<t_cd_n, t_cd_d>::den>;
 
+#define TYPE_A_FULL_PARAMS intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d
+#define TYPE_A_PARAMS t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d
+#define TYPE_B_FULL_PARAMS intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2
+#define TYPE_B_PARAMS t_m_n2, t_m_d2, t_s_n2, t_s_d2, t_kg_n2, t_kg_d2, t_A_n2, t_A_d2, t_K_n2, t_K_d2, t_mol_n2, t_mol_d2, t_cd_n2, t_cd_d2
 	/*
 	 * Arithmatic operators for combining SI values.
 	 */
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr auto operator+(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val + right.val);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val + right.val);
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr auto operator-(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val - right.val);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val - right.val);
 	}
 
-	template<typename T,
-		 intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d,
-		 intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2>
+	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
 	constexpr auto operator*(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n2, t_m_d2, t_s_n2, t_s_d2, t_kg_n2, t_kg_d2, t_A_n2, t_A_d2, t_K_n2, t_K_d2, t_mol_n2, t_mol_d2, t_cd_n2, t_cd_d2> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
 		return RationalType<T,
 		    t_m_n*t_m_d2 + t_m_n2*t_m_d, t_m_d*t_m_d2,
@@ -164,12 +166,10 @@ namespace Mesi {
 		    t_cd_n*t_cd_d2 + t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val * right.val);
 	}
 
-	template<typename T,
-		 intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d,
-		 intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2>
+	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
 	constexpr auto operator/(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n2, t_m_d2, t_s_n2, t_s_d2, t_kg_n2, t_kg_d2, t_A_n2, t_A_d2, t_K_n2, t_K_d2, t_mol_n2, t_mol_d2, t_cd_n2, t_cd_d2> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
 		return RationalType<T,
 		    t_m_n*t_m_d2 - t_m_n2*t_m_d, t_m_d*t_m_d2,
@@ -185,52 +185,52 @@ namespace Mesi {
 	 * Unary operators, to help with literals (and general usage!)
 	 */
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr auto operator-(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& op
+		RationalTypeReduced<TYPE_A_PARAMS> const& op
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(-op.val);
+		return RationalTypeReduced<TYPE_A_PARAMS>(-op.val);
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr auto operator+(
-			RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& op
+			RationalTypeReduced<TYPE_A_PARAMS> const& op
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(op);
+		return RationalTypeReduced<TYPE_A_PARAMS>(op);
 	}
 
 	/*
 	 * Scalers by non-SI values (allows things like 2 * 3._m
 	 */
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	template<TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator*(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val * right);
+		return RationalTypeReduced<TYPE_A_PARAMS>(left.val * right);
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	template<TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator*(
 		S const & left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return right * left;
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	template<TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator/(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val / right);
+		return RationalTypeReduced<TYPE_A_PARAMS>(left.val / right);
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	template<TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator/(
 		S const & left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return RationalTypeReduced<T, -t_m_n, t_m_d, -t_s_n, t_s_d, -t_kg_n, t_kg_d, -t_A_n, t_A_d, -t_K_n, t_K_d, -t_mol_n, t_mol_d, -t_cd_n, t_cd_d>( left / right.val );
 	}
@@ -238,53 +238,58 @@ namespace Mesi {
 	/*
 	 * Comparison operators
 	 */
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator==(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return left.val == right.val;
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator<(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return left.val < right.val;
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator!=(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return !(right == left);
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator<=(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return left < right || left == right;
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator>(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return right < left;
 	}
 
-	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	template<TYPE_A_FULL_PARAMS>
 	constexpr bool operator>=(
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
-		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<TYPE_A_PARAMS> const& right
 	) {
 		return left > right || left == right;
 	}
+
+#undef TYPE_A_FULL_PARAMS
+#undef TYPE_A_PARAMS
+#undef TYPE_B_FULL_PARAMS
+#undef TYPE_B_PARAMS
 
 	/*
 	 * Readable names for common types

--- a/mesitype.h
+++ b/mesitype.h
@@ -4,6 +4,9 @@
 #include <ratio>
 
 namespace Mesi {
+/* Utility macro for applying another macro to all known units, for internal use only */
+#define ALL_UNITS(op) op(m) op(s) op(kg) op(A) op(K) op(mol) op(cd)
+
 	/**
 	 * @brief Main class to store SI types
 	 *
@@ -76,15 +79,7 @@ namespace Mesi {
 				return s_unitString;
 
 #define DIM_TO_STRING(TP) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#TP) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#TP) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else s_unitString += std::string(#TP) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
-
-			DIM_TO_STRING(m);
-			DIM_TO_STRING(s);
-			DIM_TO_STRING(kg);
-			DIM_TO_STRING(A);
-			DIM_TO_STRING(K);
-			DIM_TO_STRING(mol);
-			DIM_TO_STRING(cd);
-
+			ALL_UNITS(DIM_TO_STRING)
 #undef DIM_TO_STRING
 			
 			s_unitString = s_unitString.substr(0, s_unitString.size() - 1);
@@ -137,7 +132,6 @@ namespace Mesi {
 		std::ratio<t_mol_n, t_mol_d>::num, std::ratio<t_mol_n, t_mol_d>::den,
 		std::ratio<t_cd_n, t_cd_d>::num, std::ratio<t_cd_n, t_cd_d>::den>;
 
-#define ALL_UNITS(op) op(m) op(s) op(kg) op(A) op(K) op(mol) op(cd)
 #define TYPE_A_FULL_PARAMS intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d
 #define TYPE_A_PARAMS t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d
 #define TYPE_B_FULL_PARAMS intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2
@@ -179,8 +173,8 @@ namespace Mesi {
 	) {
 #define SUB_FRAC(TP) using TP = std::ratio_subtract<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>;
 		ALL_UNITS(SUB_FRAC)
+	#undef SUB_FRAC
 		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val / right.val);
-#undef SUB_FRAC
 	}
 
 	/*
@@ -292,6 +286,7 @@ namespace Mesi {
 #undef TYPE_A_PARAMS
 #undef TYPE_B_FULL_PARAMS
 #undef TYPE_B_PARAMS
+#undef ALL_UNITS
 
 	/*
 	 * Readable names for common types
@@ -336,7 +331,7 @@ namespace Mesi {
 	 * Note that this defaults to the type set below, if no other is set
 	 * before calling!
 	 *
-	 * These are all lowercase, as user-defined literals beginning with
+	 * These are all lowercase, as identifiers beginning with
 	 * _[A-Z] are reserved.
 	 */
 #define LITERAL_TYPE(T, SUFFIX) \

--- a/mesitype.h
+++ b/mesitype.h
@@ -8,15 +8,23 @@ namespace Mesi {
 	 * @brief Main class to store SI types
 	 *
 	 * @param T storage type parameter
-	 * @param t_m number of dimensions of meters, e.g., t_m == 2 => m^2
-	 * @param t_s similar to t_m, but seconds
-	 * @param t_kg similar to t_m, but kilograms
+	 * @param t_m_n, t_m_d number of dimensions of meters as a rational number, e.g., t_m_n/t_m_d == 2 => m^2
+	 * @param t_s_* similar to t_m, but seconds
+	 * @param t_kg_* similar to t_m, but kilograms
+	 * @param t_A_* similar to t_m, but amperes
+	 * @param t_K_* similar to t_m, but Kelvin
+	 * @param t_mol_* similar to t_m, but moles
+	 * @param t_cd_* similar to t_m, but candela
 	 *
 	 * This class is to enforce compile-time checking, and where possible,
 	 * compile-time calculation of SI values using constexpr.
 	 *
 	 * Note: MESI_LITERAL_TYPE may be defined to set the storage type
 	 * used by the operator literal overloads
+	 *
+	 * Note: Fractions must be reduced, i.e. the greatest common divisor
+	 * of numerator and denominator must be 1. To prevent compile-time
+	 * errors, use RationalType<>, which reduces fractions automatically.
 	 *
 	 * @author Jameson Thatcher (a.k.a. SirEel)
 	 *

--- a/mesitype.h
+++ b/mesitype.h
@@ -156,14 +156,15 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
+
 		return RationalType<T,
-		    t_m_n*t_m_d2 + t_m_n2*t_m_d, t_m_d*t_m_d2,
-		    t_s_n*t_s_d2 + t_s_n2*t_s_d, t_s_d*t_s_d2,
-		    t_kg_n*t_kg_d2 + t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
-		    t_A_n*t_A_d2 + t_A_n2*t_A_d, t_A_d*t_A_d2,
-		    t_K_n*t_K_d2 + t_K_n2*t_K_d, t_K_d*t_K_d2,
-		    t_mol_n*t_mol_d2 + t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
-		    t_cd_n*t_cd_d2 + t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val * right.val);
+			t_m_n*t_m_d2 + t_m_n2*t_m_d, t_m_d*t_m_d2,
+			t_s_n*t_s_d2 + t_s_n2*t_s_d, t_s_d*t_s_d2,
+			t_kg_n*t_kg_d2 + t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
+			t_A_n*t_A_d2 + t_A_n2*t_A_d, t_A_d*t_A_d2,
+			t_K_n*t_K_d2 + t_K_n2*t_K_d, t_K_d*t_K_d2,
+			t_mol_n*t_mol_d2 + t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
+			t_cd_n*t_cd_d2 + t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val * right.val);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
@@ -172,13 +173,13 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
 		return RationalType<T,
-		    t_m_n*t_m_d2 - t_m_n2*t_m_d, t_m_d*t_m_d2,
-		    t_s_n*t_s_d2 - t_s_n2*t_s_d, t_s_d*t_s_d2,
-		    t_kg_n*t_kg_d2 - t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
-		    t_A_n*t_A_d2 - t_A_n2*t_A_d, t_A_d*t_A_d2,
-		    t_K_n*t_K_d2 - t_K_n2*t_K_d, t_K_d*t_K_d2,
-		    t_mol_n*t_mol_d2 - t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
-		    t_cd_n*t_cd_d2 - t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val / right.val);
+			t_m_n*t_m_d2 - t_m_n2*t_m_d, t_m_d*t_m_d2,
+			t_s_n*t_s_d2 - t_s_n2*t_s_d, t_s_d*t_s_d2,
+			t_kg_n*t_kg_d2 - t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
+			t_A_n*t_A_d2 - t_A_n2*t_A_d, t_A_d*t_A_d2,
+			t_K_n*t_K_d2 - t_K_n2*t_K_d, t_K_d*t_K_d2,
+			t_mol_n*t_mol_d2 - t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
+			t_cd_n*t_cd_d2 - t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val / right.val);
 	}
 
 	/*

--- a/mesitype.h
+++ b/mesitype.h
@@ -335,9 +335,10 @@ namespace Mesi {
 	 * Literal operators, to allow quick creation of basic types
 	 * Note that this defaults to the type set below, if no other is set
 	 * before calling!
+	 *
+	 * These are all lowercase, as user-defined literals beginning with
+	 * _[A-Z] are reserved.
 	 */
-#pragma push_macro("_N")
-#undef _N
 #define LITERAL_TYPE(T, SUFFIX) \
 			constexpr auto operator "" SUFFIX(long double arg) { return T(arg); } \
 			constexpr auto operator "" SUFFIX(unsigned long long arg) { return T(arg); }
@@ -348,25 +349,24 @@ namespace Mesi {
 		LITERAL_TYPE(Mesi::SecondsSq, _s2)
 		LITERAL_TYPE(Mesi::Kilos, _kg)
 		LITERAL_TYPE(Mesi::KilosSq, _kg2)
-		LITERAL_TYPE(Mesi::Newtons, _N)
-		LITERAL_TYPE(Mesi::NewtonsSq, _N2)
-		LITERAL_TYPE(Mesi::Hertz, _Hz)
-		LITERAL_TYPE(Mesi::Amperes, _A)
-		LITERAL_TYPE(Mesi::Kelvin, _K)
+		LITERAL_TYPE(Mesi::Newtons, _n)
+		LITERAL_TYPE(Mesi::NewtonsSq, _n2)
+		LITERAL_TYPE(Mesi::Hertz, _hz)
+		LITERAL_TYPE(Mesi::Amperes, _a)
+		LITERAL_TYPE(Mesi::Kelvin, _k)
 		LITERAL_TYPE(Mesi::Moles, _mol)
 		LITERAL_TYPE(Mesi::Candela, _cd)
-		LITERAL_TYPE(Mesi::Pascals, _Pa)
-		LITERAL_TYPE(Mesi::Joules, _J)
-		LITERAL_TYPE(Mesi::Watts, _W)
-		LITERAL_TYPE(Mesi::Coulombs, _C)
-		LITERAL_TYPE(Mesi::Volts, _V)
-		LITERAL_TYPE(Mesi::Farads, _F)
+		LITERAL_TYPE(Mesi::Pascals, _pa)
+		LITERAL_TYPE(Mesi::Joules, _j)
+		LITERAL_TYPE(Mesi::Watts, _w)
+		LITERAL_TYPE(Mesi::Coulombs, _c)
+		LITERAL_TYPE(Mesi::Volts, _v)
+		LITERAL_TYPE(Mesi::Farads, _f)
 		LITERAL_TYPE(Mesi::Ohms, _ohm)
-		LITERAL_TYPE(Mesi::Siemens, _S)
-		LITERAL_TYPE(Mesi::Webers, _Wb)
-		LITERAL_TYPE(Mesi::Tesla, _T)
-		LITERAL_TYPE(Mesi::Henry, _H)
+		LITERAL_TYPE(Mesi::Siemens, _siemens)
+		LITERAL_TYPE(Mesi::Webers, _wb)
+		LITERAL_TYPE(Mesi::Tesla, _t)
+		LITERAL_TYPE(Mesi::Henry, _h)
 #undef LITERAL_TYPE
 	}
-#pragma pop_macro("_N")
 }

--- a/mesitype.h
+++ b/mesitype.h
@@ -137,6 +137,7 @@ namespace Mesi {
 		std::ratio<t_mol_n, t_mol_d>::num, std::ratio<t_mol_n, t_mol_d>::den,
 		std::ratio<t_cd_n, t_cd_d>::num, std::ratio<t_cd_n, t_cd_d>::den>;
 
+#define ALL_UNITS(op) op(m) op(s) op(kg) op(A) op(K) op(mol) op(cd)
 #define TYPE_A_FULL_PARAMS intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d
 #define TYPE_A_PARAMS t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d
 #define TYPE_B_FULL_PARAMS intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2
@@ -165,16 +166,10 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-#define ADD_FRAC(TP) using TP = std::ratio_add<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>
-		ADD_FRAC(m);
-		ADD_FRAC(kg);
-		ADD_FRAC(s);
-		ADD_FRAC(A);
-		ADD_FRAC(K);
-		ADD_FRAC(mol);
-		ADD_FRAC(cd);
-		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val * right.val);
+#define ADD_FRAC(TP) using TP = std::ratio_add<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>;
+		ALL_UNITS(ADD_FRAC)
 #undef ADD_FRAC
+		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val * right.val);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
@@ -182,14 +177,8 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-#define SUB_FRAC(TP) using TP = std::ratio_subtract<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>
-		SUB_FRAC(m);
-		SUB_FRAC(kg);
-		SUB_FRAC(s);
-		SUB_FRAC(A);
-		SUB_FRAC(K);
-		SUB_FRAC(mol);
-		SUB_FRAC(cd);
+#define SUB_FRAC(TP) using TP = std::ratio_subtract<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>;
+		ALL_UNITS(SUB_FRAC)
 		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val / right.val);
 #undef SUB_FRAC
 	}
@@ -317,29 +306,29 @@ namespace Mesi {
 
 	using Scalar    = Type<MESI_LITERAL_TYPE, 0, 0, 0>;
 	using Meters    = Type<MESI_LITERAL_TYPE, 1, 0, 0>;
-	using MetersSq  = Type<MESI_LITERAL_TYPE, 2, 0, 0>;
 	using Seconds   = Type<MESI_LITERAL_TYPE, 0, 1, 0>;
-	using SecondsSq = Type<MESI_LITERAL_TYPE, 0, 2, 0>;
 	using Kilos     = Type<MESI_LITERAL_TYPE, 0, 0, 1>;
-	using KilosSq   = Type<MESI_LITERAL_TYPE, 0, 0, 2>;
-	using Newtons   = Type<MESI_LITERAL_TYPE, 1, -2, 1>;
-	using NewtonsSq = Type<MESI_LITERAL_TYPE, 2, -4, 2>;
-	using Hertz     = Type<MESI_LITERAL_TYPE, 0, -1, 0>;
 	using Amperes   = Type<MESI_LITERAL_TYPE, 0, 0, 0, 1>;
 	using Kelvin    = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 1>;
 	using Moles     = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 0, 1>;
 	using Candela   = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 0, 0, 1>;
-	using Pascals   = decltype(Newtons(1)/MetersSq(1));
-	using Joules    = decltype(Newtons(1)*Meters(1));
-	using Watts     = decltype(Joules(1)/Seconds(1));
-	using Coulombs  = decltype(Amperes(1)*Seconds(1));
-	using Volts     = decltype(Watts(1)/Amperes(1));
-	using Farads    = decltype(Coulombs(1)/Volts(1));
-	using Ohms      = decltype(Volts(1)/Amperes(1));
-	using Siemens   = decltype(Amperes(1)/Volts(1));
-	using Webers    = decltype(Volts(1)*Seconds(1));
-	using Tesla     = decltype(Webers(1)/MetersSq(1));
-	using Henry     = decltype(Webers(1)/Amperes(1));
+	using Newtons   = decltype(Meters{} * Kilos{} / Seconds{} / Seconds{});
+	using NewtonsSq = decltype(Newtons{} * Newtons{});
+	using MetersSq  = decltype(Meters{} * Meters{});
+	using SecondsSq = decltype(Seconds{} * Seconds{});
+	using KilosSq   = decltype(Kilos{} * Kilos{});
+	using Hertz     = decltype(Scalar{} / Seconds{});
+	using Pascals   = decltype(Newtons{} / MetersSq{});
+	using Joules    = decltype(Newtons{} * Meters{});
+	using Watts     = decltype(Joules{} / Seconds{});
+	using Coulombs  = decltype(Amperes{} * Seconds{});
+	using Volts     = decltype(Watts{} / Amperes{});
+	using Farads    = decltype(Coulombs{} / Volts{});
+	using Ohms      = decltype(Volts{} / Amperes{});
+	using Siemens   = decltype(Amperes{} / Volts{});
+	using Webers    = decltype(Volts{} * Seconds{});
+	using Tesla     = decltype(Webers{} / MetersSq{});
+	using Henry     = decltype(Webers{} / Amperes{});
 
 	namespace Literals {
 	/*

--- a/mesitype.h
+++ b/mesitype.h
@@ -226,7 +226,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val / right);
+		return left / typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType(T(right));
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -234,7 +234,7 @@ namespace Mesi {
 		S const & left,
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<T, -t_m_n, t_m_d, -t_s_n, t_s_d, -t_kg_n, t_kg_d, -t_A_n, t_A_d, -t_K_n, t_K_d, -t_mol_n, t_mol_d, -t_cd_n, t_cd_d>( left / right.val );
+		return typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType(T(left)) / right;
 	}
 
 	/*

--- a/mesitype.h
+++ b/mesitype.h
@@ -45,13 +45,13 @@ namespace Mesi {
 		using BaseType = T;
 		using ScalarType = RationalTypeReduced<T, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1>;
 
-		static_assert(std::ratio<t_m_n, t_m_d>::num == t_m_n);
-		static_assert(std::ratio<t_s_n, t_s_d>::num == t_s_n);
-		static_assert(std::ratio<t_kg_n, t_kg_d>::num == t_kg_n);
-		static_assert(std::ratio<t_A_n, t_A_d>::num == t_A_n);
-		static_assert(std::ratio<t_K_n, t_K_d>::num == t_K_n);
-		static_assert(std::ratio<t_mol_n, t_mol_d>::num == t_mol_n);
-		static_assert(std::ratio<t_cd_n, t_cd_d>::num == t_cd_n);
+		static_assert(std::ratio<t_m_n, t_m_d>::num == t_m_n, "The meter exponent fraction is not irreducible");
+		static_assert(std::ratio<t_s_n, t_s_d>::num == t_s_n, "The second exponent fraction is not irreducible");
+		static_assert(std::ratio<t_kg_n, t_kg_d>::num == t_kg_n, "The kilogram exponent fraction is not irreducible");
+		static_assert(std::ratio<t_A_n, t_A_d>::num == t_A_n, "The ampere exponent fraction is not irreducible");
+		static_assert(std::ratio<t_K_n, t_K_d>::num == t_K_n, "The Kelvin exponent fraction is not irreducible");
+		static_assert(std::ratio<t_mol_n, t_mol_d>::num == t_mol_n, "The mole exponent fraction is not irreducible");
+		static_assert(std::ratio<t_cd_n, t_cd_d>::num == t_cd_n, "The candela exponent fraction is not irreducible");
 
 		T val;
 

--- a/mesitype.h
+++ b/mesitype.h
@@ -156,15 +156,16 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-
-		return RationalType<T,
-			t_m_n*t_m_d2 + t_m_n2*t_m_d, t_m_d*t_m_d2,
-			t_s_n*t_s_d2 + t_s_n2*t_s_d, t_s_d*t_s_d2,
-			t_kg_n*t_kg_d2 + t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
-			t_A_n*t_A_d2 + t_A_n2*t_A_d, t_A_d*t_A_d2,
-			t_K_n*t_K_d2 + t_K_n2*t_K_d, t_K_d*t_K_d2,
-			t_mol_n*t_mol_d2 + t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
-			t_cd_n*t_cd_d2 + t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val * right.val);
+#define ADD_FRAC(TP) using TP = std::ratio_add<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>
+		ADD_FRAC(m);
+		ADD_FRAC(kg);
+		ADD_FRAC(s);
+		ADD_FRAC(A);
+		ADD_FRAC(K);
+		ADD_FRAC(mol);
+		ADD_FRAC(cd);
+		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val * right.val);
+#undef ADD_FRAC
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
@@ -172,66 +173,68 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-		return RationalType<T,
-			t_m_n*t_m_d2 - t_m_n2*t_m_d, t_m_d*t_m_d2,
-			t_s_n*t_s_d2 - t_s_n2*t_s_d, t_s_d*t_s_d2,
-			t_kg_n*t_kg_d2 - t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
-			t_A_n*t_A_d2 - t_A_n2*t_A_d, t_A_d*t_A_d2,
-			t_K_n*t_K_d2 - t_K_n2*t_K_d, t_K_d*t_K_d2,
-			t_mol_n*t_mol_d2 - t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
-			t_cd_n*t_cd_d2 - t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val / right.val);
+#define SUB_FRAC(TP) using TP = std::ratio_subtract<std::ratio<t_##TP##_n, t_##TP##_d>, std::ratio<t_##TP##_n2, t_##TP##_d2>>
+		SUB_FRAC(m);
+		SUB_FRAC(kg);
+		SUB_FRAC(s);
+		SUB_FRAC(A);
+		SUB_FRAC(K);
+		SUB_FRAC(mol);
+		SUB_FRAC(cd);
+		return RationalType<T, m::num, m::den, s::num, s::den, kg::num, kg::den, A::num, A::den, K::num, K::den, mol::num, mol::den, cd::num, cd::den>(left.val / right.val);
+#undef SUB_FRAC
 	}
 
 	/*
 	 * Unary operators, to help with literals (and general usage!)
 	 */
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr auto operator-(
-		RationalTypeReduced<TYPE_A_PARAMS> const& op
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& op
 	) {
-		return RationalTypeReduced<TYPE_A_PARAMS>(-op.val);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(-op.val);
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr auto operator+(
-			RationalTypeReduced<TYPE_A_PARAMS> const& op
+			RationalTypeReduced<T, TYPE_A_PARAMS> const& op
 	) {
-		return RationalTypeReduced<TYPE_A_PARAMS>(op);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(op);
 	}
 
 	/*
 	 * Scalers by non-SI values (allows things like 2 * 3._m
 	 */
 
-	template<TYPE_A_FULL_PARAMS, typename S>
+	template<typename T, TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator*(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<TYPE_A_PARAMS>(left.val * right);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val * right);
 	}
 
-	template<TYPE_A_FULL_PARAMS, typename S>
+	template<typename T, TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator*(
 		S const & left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return right * left;
 	}
 
-	template<TYPE_A_FULL_PARAMS, typename S>
+	template<typename T, TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator/(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<TYPE_A_PARAMS>(left.val / right);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val / right);
 	}
 
-	template<TYPE_A_FULL_PARAMS, typename S>
+	template<typename T, TYPE_A_FULL_PARAMS, typename S>
 	constexpr auto operator/(
 		S const & left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return RationalTypeReduced<T, -t_m_n, t_m_d, -t_s_n, t_s_d, -t_kg_n, t_kg_d, -t_A_n, t_A_d, -t_K_n, t_K_d, -t_mol_n, t_mol_d, -t_cd_n, t_cd_d>( left / right.val );
 	}
@@ -239,50 +242,50 @@ namespace Mesi {
 	/*
 	 * Comparison operators
 	 */
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator==(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return left.val == right.val;
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator<(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return left.val < right.val;
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator!=(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return !(right == left);
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator<=(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return left < right || left == right;
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator>(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return right < left;
 	}
 
-	template<TYPE_A_FULL_PARAMS>
+	template<typename T, TYPE_A_FULL_PARAMS>
 	constexpr bool operator>=(
-		RationalTypeReduced<TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<TYPE_A_PARAMS> const& right
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
+		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
 		return left > right || left == right;
 	}

--- a/mesitype.h
+++ b/mesitype.h
@@ -220,7 +220,8 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return left / typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType(T(right));
+		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
+		return left / Scalar(T(right));
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -228,7 +229,8 @@ namespace Mesi {
 		S const & left,
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType(T(left)) / right;
+		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
+		return Scalar(T(left)) / right;
 	}
 
 	/*

--- a/mesitype.h
+++ b/mesitype.h
@@ -312,6 +312,7 @@ namespace Mesi {
 	using Newtons   = decltype(Meters{} * Kilos{} / Seconds{} / Seconds{});
 	using NewtonsSq = decltype(Newtons{} * Newtons{});
 	using MetersSq  = decltype(Meters{} * Meters{});
+	using MetersCu  = decltype(Meters{} * MetersSq{});
 	using SecondsSq = decltype(Seconds{} * Seconds{});
 	using KilosSq   = decltype(Kilos{} * Kilos{});
 	using Hertz     = decltype(Scalar{} / Seconds{});
@@ -342,6 +343,7 @@ namespace Mesi {
 
 		LITERAL_TYPE(Mesi::Meters, _m)
 		LITERAL_TYPE(Mesi::MetersSq, _m2)
+		LITERAL_TYPE(Mesi::MetersCu, _m3)
 		LITERAL_TYPE(Mesi::Seconds, _s)
 		LITERAL_TYPE(Mesi::SecondsSq, _s2)
 		LITERAL_TYPE(Mesi::Kilos, _kg)

--- a/mesitype.h
+++ b/mesitype.h
@@ -311,11 +311,11 @@ namespace Mesi {
 	using MetersSq  = Type<MESI_LITERAL_TYPE, 2, 0, 0>;
 	using Seconds   = Type<MESI_LITERAL_TYPE, 0, 1, 0>;
 	using SecondsSq = Type<MESI_LITERAL_TYPE, 0, 2, 0>;
-	using Hertz     = Type<MESI_LITERAL_TYPE, 0, -1, 0>;
 	using Kilos     = Type<MESI_LITERAL_TYPE, 0, 0, 1>;
 	using KilosSq   = Type<MESI_LITERAL_TYPE, 0, 0, 2>;
 	using Newtons   = Type<MESI_LITERAL_TYPE, 1, -2, 1>;
 	using NewtonsSq = Type<MESI_LITERAL_TYPE, 2, -4, 2>;
+	using Hertz     = Type<MESI_LITERAL_TYPE, 0, -1, 0>;
 	using Amperes   = Type<MESI_LITERAL_TYPE, 0, 0, 0, 1>;
 	using Kelvin    = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 1>;
 	using Moles     = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 0, 1>;
@@ -326,7 +326,7 @@ namespace Mesi {
 	using Coulombs  = decltype(Amperes(1)*Seconds(1));
 	using Volts     = decltype(Watts(1)/Amperes(1));
 	using Farads    = decltype(Coulombs(1)/Volts(1));
-	using Ohm       = decltype(Volts(1)/Amperes(1));
+	using Ohms      = decltype(Volts(1)/Amperes(1));
 	using Siemens   = decltype(Amperes(1)/Volts(1));
 	using Webers    = decltype(Volts(1)*Seconds(1));
 	using Tesla     = decltype(Webers(1)/MetersSq(1));
@@ -340,70 +340,35 @@ namespace Mesi {
 	 */
 #pragma push_macro("_N")
 #undef _N
+#define LITERAL_TYPE(T, SUFFIX) \
+			constexpr auto operator "" SUFFIX(long double arg) { return T(arg); } \
+			constexpr auto operator "" SUFFIX(unsigned long long arg) { return T(arg); }
 
-		constexpr Mesi::Meters operator "" _m(long double arg) {
-			return Mesi::Meters(arg);
-		}
-
-		constexpr Mesi::Seconds operator "" _s(long double arg) {
-			return Mesi::Seconds(arg);
-		}
-
-		constexpr Mesi::Kilos operator "" _kg(long double arg) {
-			return Mesi::Kilos(arg);
-		}
-
-		constexpr Mesi::Newtons operator "" _N(long double arg) {
-			return Mesi::Newtons(arg);
-		}
-
-		constexpr Mesi::Meters operator "" _m(unsigned long long arg) {
-			return Mesi::Meters(arg);
-		}
-
-		constexpr Mesi::Seconds operator "" _s(unsigned long long arg) {
-			return Mesi::Seconds(arg);
-		}
-
-		constexpr Mesi::Kilos operator "" _kg(unsigned long long arg) {
-			return Mesi::Kilos(arg);
-		}
-
-		constexpr Mesi::Newtons operator "" _N(unsigned long long arg) {
-			return Mesi::Newtons(arg);
-		}
-
-		constexpr Mesi::MetersSq operator "" _m2(long double arg) {
-			return Mesi::MetersSq(arg);
-		}
-
-		constexpr Mesi::SecondsSq operator "" _s2(long double arg) {
-			return Mesi::SecondsSq(arg);
-		}
-
-		constexpr Mesi::KilosSq operator "" _kg2(long double arg) {
-			return Mesi::KilosSq(arg);
-		}
-
-		constexpr Mesi::NewtonsSq operator "" _N2(long double arg) {
-			return Mesi::NewtonsSq(arg);
-		}
-
-		constexpr Mesi::MetersSq operator "" _m2(unsigned long long arg) {
-			return Mesi::MetersSq(arg);
-		}
-
-		constexpr Mesi::SecondsSq operator "" _s2(unsigned long long arg) {
-			return Mesi::SecondsSq(arg);
-		}
-
-		constexpr Mesi::KilosSq operator "" _kg2(unsigned long long arg) {
-			return Mesi::KilosSq(arg);
-		}
-
-		constexpr Mesi::NewtonsSq operator "" _N2(unsigned long long arg) {
-			return Mesi::NewtonsSq(arg);
-		}
+		LITERAL_TYPE(Mesi::Meters, _m)
+		LITERAL_TYPE(Mesi::MetersSq, _m2)
+		LITERAL_TYPE(Mesi::Seconds, _s)
+		LITERAL_TYPE(Mesi::SecondsSq, _s2)
+		LITERAL_TYPE(Mesi::Kilos, _kg)
+		LITERAL_TYPE(Mesi::KilosSq, _kg2)
+		LITERAL_TYPE(Mesi::Newtons, _N)
+		LITERAL_TYPE(Mesi::NewtonsSq, _N2)
+		LITERAL_TYPE(Mesi::Hertz, _Hz)
+		LITERAL_TYPE(Mesi::Amperes, _A)
+		LITERAL_TYPE(Mesi::Kelvin, _K)
+		LITERAL_TYPE(Mesi::Moles, _mol)
+		LITERAL_TYPE(Mesi::Candela, _cd)
+		LITERAL_TYPE(Mesi::Pascals, _Pa)
+		LITERAL_TYPE(Mesi::Joules, _J)
+		LITERAL_TYPE(Mesi::Watts, _W)
+		LITERAL_TYPE(Mesi::Coulombs, _C)
+		LITERAL_TYPE(Mesi::Volts, _V)
+		LITERAL_TYPE(Mesi::Farads, _F)
+		LITERAL_TYPE(Mesi::Ohms, _ohm)
+		LITERAL_TYPE(Mesi::Siemens, _S)
+		LITERAL_TYPE(Mesi::Webers, _Wb)
+		LITERAL_TYPE(Mesi::Tesla, _T)
+		LITERAL_TYPE(Mesi::Henry, _H)
+#undef LITERAL_TYPE
 	}
 #pragma pop_macro("_N")
 }

--- a/mesitype.h
+++ b/mesitype.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <ratio>
 
 namespace Mesi {
 	/**
@@ -20,19 +21,37 @@ namespace Mesi {
 	 * @author Jameson Thatcher (a.k.a. SirEel)
 	 *
 	 */
-	template<typename T, int t_m, int t_s, int t_kg>
-	struct Type {
+	template<typename T,
+		intmax_t t_m_n, intmax_t t_m_d,
+		intmax_t t_s_n, intmax_t t_s_d,
+		intmax_t t_kg_n, intmax_t t_kg_d,
+		intmax_t t_A_n, intmax_t t_A_d,
+		intmax_t t_K_n, intmax_t t_K_d,
+		intmax_t t_mol_n, intmax_t t_mol_d,
+		intmax_t t_cd_n, intmax_t t_cd_d>
+	struct RationalTypeReduced
+	{
 		using BaseType = T;
+		using ScalarType = RationalTypeReduced<T, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1>;
+
+		static_assert(std::ratio<t_m_n, t_m_d>::num == t_m_n);
+		static_assert(std::ratio<t_s_n, t_s_d>::num == t_s_n);
+		static_assert(std::ratio<t_kg_n, t_kg_d>::num == t_kg_n);
+		static_assert(std::ratio<t_A_n, t_A_d>::num == t_A_n);
+		static_assert(std::ratio<t_K_n, t_K_d>::num == t_K_n);
+		static_assert(std::ratio<t_mol_n, t_mol_d>::num == t_mol_n);
+		static_assert(std::ratio<t_cd_n, t_cd_d>::num == t_cd_n);
+
 		T val;
 
-		constexpr Type()
+		constexpr RationalTypeReduced()
 		{}
 
-		constexpr explicit Type(T const in)
+		constexpr explicit RationalTypeReduced(T const in)
 			:val(in)
 		{}
 
-		constexpr Type(Type const& in)
+		constexpr RationalTypeReduced(RationalTypeReduced const& in)
 			:val(in.val)
 		{}
 
@@ -47,58 +66,232 @@ namespace Mesi {
 			static std::string s_unitString("");
 			if( s_unitString.size() > 0 )
 				return s_unitString;
+#define DIM_TO_STRING(TP, NAME) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#NAME) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#NAME) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else s_unitString += std::string(#NAME) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
 
-			if( t_m == 1 )
-				s_unitString += "m ";
-			else if( t_m != 0 )
-				s_unitString += "m^"
-					+ std::to_string(static_cast<long long>(t_m)) + " ";
-			if( t_s == 1 )
-				s_unitString += "s ";
-			else if( t_s != 0 )
-				s_unitString += "s^"
-					+ std::to_string(static_cast<long long>(t_s)) + " ";
-			if( t_kg == 1 )
-				s_unitString += "kg ";
-			else if( t_kg != 0 )
-				s_unitString += "kg^"
-					+ std::to_string(static_cast<long long>(t_kg)) + " ";
+			DIM_TO_STRING(m, "m");
+			DIM_TO_STRING(s, "s");
+			DIM_TO_STRING(kg, "kg");
+			DIM_TO_STRING(A, "A");
+			DIM_TO_STRING(K, "K");
+			DIM_TO_STRING(mol, "mol");
+			DIM_TO_STRING(cd, "cd");
+
+#undef DIM_TO_STRING
+			
 			s_unitString = s_unitString.substr(0, s_unitString.size() - 1);
 			return s_unitString;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator+=(
-			Type<T, t_m, t_s, t_kg> const& rhs
+		RationalTypeReduced& operator+=(
+			RationalTypeReduced const& rhs
 		) {
 			return (*this) = (*this) + rhs;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator-=(
-			Type<T, t_m, t_s, t_kg> const& rhs
+		RationalTypeReduced& operator-=(
+			RationalTypeReduced const& rhs
 		) {
 			return (*this) = (*this) - rhs;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator*=(T const& rhs) {
+		RationalTypeReduced& operator*=(T const& rhs) {
 			return (*this) = (*this) * rhs;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator/=(T const& rhs) {
+		RationalTypeReduced& operator/=(T const& rhs) {
 			return (*this) = (*this) / rhs;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator*=(Type<T, 0, 0, 0> const& rhs) {
+		RationalTypeReduced& operator*=(ScalarType const& rhs) {
 			return (*this) = (*this) * rhs;
 		}
 
-		Type<T, t_m, t_s, t_kg>& operator/=(Type<T, 0, 0, 0> const& rhs) {
+		RationalTypeReduced& operator/=(ScalarType const& rhs) {
 			return (*this) = (*this) / rhs;
 		}
 	};
 
+	template<typename T,
+		intmax_t t_m_n, intmax_t t_m_d,
+		intmax_t t_s_n, intmax_t t_s_d,
+		intmax_t t_kg_n, intmax_t t_kg_d,
+		intmax_t t_A_n, intmax_t t_A_d,
+		intmax_t t_K_n, intmax_t t_K_d,
+		intmax_t t_mol_n, intmax_t t_mol_d,
+		intmax_t t_cd_n, intmax_t t_cd_d>
+	using RationalType = RationalTypeReduced<T,
+		std::ratio<t_m_n, t_m_d>::num, std::ratio<t_m_n, t_m_d>::den,
+		std::ratio<t_s_n, t_s_d>::num, std::ratio<t_s_n, t_s_d>::den,
+		std::ratio<t_kg_n, t_kg_d>::num, std::ratio<t_kg_n, t_kg_d>::den,
+		std::ratio<t_A_n, t_A_d>::num, std::ratio<t_A_n, t_A_d>::den,
+		std::ratio<t_K_n, t_K_d>::num, std::ratio<t_K_n, t_K_d>::den,
+		std::ratio<t_mol_n, t_mol_d>::num, std::ratio<t_mol_n, t_mol_d>::den,
+		std::ratio<t_cd_n, t_cd_d>::num, std::ratio<t_cd_n, t_cd_d>::den>;
+
+	/*
+	 * Arithmatic operators for combining SI values.
+	 */
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr auto operator+(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val + right.val);
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr auto operator-(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val - right.val);
+	}
+
+	template<typename T,
+		 intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d,
+		 intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2>
+	constexpr auto operator*(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n2, t_m_d2, t_s_n2, t_s_d2, t_kg_n2, t_kg_d2, t_A_n2, t_A_d2, t_K_n2, t_K_d2, t_mol_n2, t_mol_d2, t_cd_n2, t_cd_d2> const& right
+	) {
+		return RationalType<T,
+		    t_m_n*t_m_d2 + t_m_n2*t_m_d, t_m_d*t_m_d2,
+		    t_s_n*t_s_d2 + t_s_n2*t_s_d, t_s_d*t_s_d2,
+		    t_kg_n*t_kg_d2 + t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
+		    t_A_n*t_A_d2 + t_A_n2*t_A_d, t_A_d*t_A_d2,
+		    t_K_n*t_K_d2 + t_K_n2*t_K_d, t_K_d*t_K_d2,
+		    t_mol_n*t_mol_d2 + t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
+		    t_cd_n*t_cd_d2 + t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val * right.val);
+	}
+
+	template<typename T,
+		 intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d,
+		 intmax_t t_m_n2, intmax_t t_m_d2, intmax_t t_s_n2, intmax_t t_s_d2, intmax_t t_kg_n2, intmax_t t_kg_d2, intmax_t t_A_n2, intmax_t t_A_d2, intmax_t t_K_n2, intmax_t t_K_d2, intmax_t t_mol_n2, intmax_t t_mol_d2, intmax_t t_cd_n2, intmax_t t_cd_d2>
+	constexpr auto operator/(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n2, t_m_d2, t_s_n2, t_s_d2, t_kg_n2, t_kg_d2, t_A_n2, t_A_d2, t_K_n2, t_K_d2, t_mol_n2, t_mol_d2, t_cd_n2, t_cd_d2> const& right
+	) {
+		return RationalType<T,
+		    t_m_n*t_m_d2 - t_m_n2*t_m_d, t_m_d*t_m_d2,
+		    t_s_n*t_s_d2 - t_s_n2*t_s_d, t_s_d*t_s_d2,
+		    t_kg_n*t_kg_d2 - t_kg_n2*t_kg_d, t_kg_d*t_kg_d2,
+		    t_A_n*t_A_d2 - t_A_n2*t_A_d, t_A_d*t_A_d2,
+		    t_K_n*t_K_d2 - t_K_n2*t_K_d, t_K_d*t_K_d2,
+		    t_mol_n*t_mol_d2 - t_mol_n2*t_mol_d, t_mol_d*t_mol_d2,
+		    t_cd_n*t_cd_d2 - t_cd_n2*t_cd_d, t_cd_d*t_cd_d2>(left.val / right.val);
+	}
+
+	/*
+	 * Unary operators, to help with literals (and general usage!)
+	 */
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr auto operator-(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& op
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(-op.val);
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr auto operator+(
+			RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& op
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(op);
+	}
+
+	/*
+	 * Scalers by non-SI values (allows things like 2 * 3._m
+	 */
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	constexpr auto operator*(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		S const& right
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val * right);
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	constexpr auto operator*(
+		S const & left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return right * left;
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	constexpr auto operator/(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		S const& right
+	) {
+		return RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d>(left.val / right);
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d, typename S>
+	constexpr auto operator/(
+		S const & left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return RationalTypeReduced<T, -t_m_n, t_m_d, -t_s_n, t_s_d, -t_kg_n, t_kg_d, -t_A_n, t_A_d, -t_K_n, t_K_d, -t_mol_n, t_mol_d, -t_cd_n, t_cd_d>( left / right.val );
+	}
+
+	/*
+	 * Comparison operators
+	 */
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator==(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return left.val == right.val;
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator<(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return left.val < right.val;
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator!=(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return !(right == left);
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator<=(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return left < right || left == right;
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator>(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return right < left;
+	}
+
+	template<typename T, intmax_t t_m_n, intmax_t t_m_d, intmax_t t_s_n, intmax_t t_s_d, intmax_t t_kg_n, intmax_t t_kg_d, intmax_t t_A_n, intmax_t t_A_d, intmax_t t_K_n, intmax_t t_K_d, intmax_t t_mol_n, intmax_t t_mol_d, intmax_t t_cd_n, intmax_t t_cd_d>
+	constexpr bool operator>=(
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& left,
+		RationalTypeReduced<T, t_m_n, t_m_d, t_s_n, t_s_d, t_kg_n, t_kg_d, t_A_n, t_A_d, t_K_n, t_K_d, t_mol_n, t_mol_d, t_cd_n, t_cd_d> const& right
+	) {
+		return left > right || left == right;
+	}
+
 	/*
 	 * Readable names for common types
 	 */
+
+	template<typename T, intmax_t t_m, intmax_t t_s, intmax_t t_kg, intmax_t t_A=0, intmax_t t_K=0, intmax_t t_mol=0, intmax_t t_cd=0>
+	using Type = RationalType<T, t_m, 1, t_s, 1, t_kg, 1, t_A, 1, t_K, 1, t_mol, 1, t_cd, 1>;
 
 #ifndef MESI_LITERAL_TYPE
 #	define MESI_LITERAL_TYPE float
@@ -109,159 +302,26 @@ namespace Mesi {
 	using MetersSq  = Type<MESI_LITERAL_TYPE, 2, 0, 0>;
 	using Seconds   = Type<MESI_LITERAL_TYPE, 0, 1, 0>;
 	using SecondsSq = Type<MESI_LITERAL_TYPE, 0, 2, 0>;
+	using Hertz     = Type<MESI_LITERAL_TYPE, 0, -1, 0>;
 	using Kilos     = Type<MESI_LITERAL_TYPE, 0, 0, 1>;
 	using KilosSq   = Type<MESI_LITERAL_TYPE, 0, 0, 2>;
 	using Newtons   = Type<MESI_LITERAL_TYPE, 1, -2, 1>;
 	using NewtonsSq = Type<MESI_LITERAL_TYPE, 2, -4, 2>;
-
-	/*
-	 * Arithmatic operators for combining SI values.
-	 */
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr Type<T, t_m, t_s, t_kg> operator+(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return Type<T, t_m, t_s, t_kg>(left.val + right.val);
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr Type<T, t_m, t_s, t_kg> operator-(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return Type<T, t_m, t_s, t_kg>(left.val - right.val);
-	}
-
-	template<typename T,
-	 	int t_m, int t_m2, int t_s, int t_s2, int t_kg, int t_kg2
-	>
-	constexpr Type<T, t_m + t_m2, t_s + t_s2, t_kg + t_kg2> operator*(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m2, t_s2, t_kg2> const& right
-	) {
-		return Type<T, t_m + t_m2, t_s + t_s2, t_kg + t_kg2>(
-			left.val * right.val
-		);
-	}
-
-	template<typename T,
-	 	int t_m, int t_m2, int t_s, int t_s2, int t_kg, int t_kg2
-	>
-	constexpr Type<T, t_m - t_m2, t_s - t_s2, t_kg - t_kg2> operator/(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m2, t_s2, t_kg2> const& right
-	) {
-		return Type<T, t_m - t_m2, t_s - t_s2, t_kg - t_kg2>(
-			left.val / right.val
-		);
-	}
-
-	/*
-	 * Unary operators, to help with literals (and general usage!)
-	 */
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr Type<T, t_m, t_s, t_kg> operator-(
-		Type<T, t_m, t_s, t_kg> const& op
-	) {
-		return Type<T, t_m, t_s, t_kg>(-op.val);
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr Type<T, t_m, t_s, t_kg> operator+(
-			Type<T, t_m, t_s, t_kg> const& op
-	) {
-		return op;
-	}
-
-	/*
-	 * Scalers by non-SI values (allows things like 2 * 3._m
-	 */
-
-	template<typename T, int t_m, int t_s, int t_kg, typename S>
-	constexpr Type<T, t_m, t_s, t_kg> operator*(
-		Type<T, t_m, t_s, t_kg> const& left,
-		S const& right
-	) {
-		return Type<T, t_m, t_s, t_kg>(left.val * right);
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg, typename S>
-	constexpr Type<T, t_m, t_s, t_kg> operator*(
-		S const & left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return right * left;
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg, typename S>
-	constexpr Type<T, t_m, t_s, t_kg> operator/(
-		Type<T, t_m, t_s, t_kg> const& left,
-		S const& right
-	) {
-		return Type<T, t_m, t_s, t_kg>(left.val / right);
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg, typename S>
-	constexpr Type<T, -t_m, -t_s, -t_kg> operator/(
-		S const & left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return Type<T, -t_m, -t_s, -t_kg>( left / right.val );
-	}
-
-	/*
-	 * Comparison operators
-	 */
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator==(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return left.val == right.val;
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator<(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return left.val < right.val;
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator!=(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return !(right == left);
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator<=(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return left < right || left == right;
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator>(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return right < left;
-	}
-
-	template<typename T, int t_m, int t_s, int t_kg>
-	constexpr bool operator>=(
-		Type<T, t_m, t_s, t_kg> const& left,
-		Type<T, t_m, t_s, t_kg> const& right
-	) {
-		return left > right || left == right;
-	}
+	using Amperes   = Type<MESI_LITERAL_TYPE, 0, 0, 0, 1>;
+	using Kelvin    = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 1>;
+	using Moles     = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 0, 1>;
+	using Candela   = Type<MESI_LITERAL_TYPE, 0, 0, 0, 0, 0, 0, 1>;
+	using Pascals   = decltype(Newtons(1)/MetersSq(1));
+	using Joules    = decltype(Newtons(1)*Meters(1));
+	using Watts     = decltype(Joules(1)/Seconds(1));
+	using Coulombs  = decltype(Amperes(1)*Seconds(1));
+	using Volts     = decltype(Watts(1)/Amperes(1));
+	using Farads    = decltype(Coulombs(1)/Volts(1));
+	using Ohm       = decltype(Volts(1)/Amperes(1));
+	using Siemens   = decltype(Amperes(1)/Volts(1));
+	using Webers    = decltype(Volts(1)*Seconds(1));
+	using Tesla     = decltype(Webers(1)/MetersSq(1));
+	using Henry     = decltype(Webers(1)/Amperes(1));
 
 	namespace Literals {
 	/*

--- a/mesitype.h
+++ b/mesitype.h
@@ -74,15 +74,16 @@ namespace Mesi {
 			static std::string s_unitString("");
 			if( s_unitString.size() > 0 )
 				return s_unitString;
-#define DIM_TO_STRING(TP, NAME) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#NAME) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#NAME) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else s_unitString += std::string(#NAME) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
 
-			DIM_TO_STRING(m, "m");
-			DIM_TO_STRING(s, "s");
-			DIM_TO_STRING(kg, "kg");
-			DIM_TO_STRING(A, "A");
-			DIM_TO_STRING(K, "K");
-			DIM_TO_STRING(mol, "mol");
-			DIM_TO_STRING(cd, "cd");
+#define DIM_TO_STRING(TP) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#TP) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#TP) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else s_unitString += std::string(#TP) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
+
+			DIM_TO_STRING(m);
+			DIM_TO_STRING(s);
+			DIM_TO_STRING(kg);
+			DIM_TO_STRING(A);
+			DIM_TO_STRING(K);
+			DIM_TO_STRING(mol);
+			DIM_TO_STRING(cd);
 
 #undef DIM_TO_STRING
 			

--- a/mesitype.h
+++ b/mesitype.h
@@ -78,7 +78,7 @@ namespace Mesi {
 			if( s_unitString.size() > 0 )
 				return s_unitString;
 
-#define DIM_TO_STRING(TP) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#TP) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#TP) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else s_unitString += std::string(#TP) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
+#define DIM_TO_STRING(TP) if( t_##TP##_n == 1 && t_##TP##_d == 1 ) s_unitString += std::string(#TP) + " "; else if( t_##TP##_n != 0 && t_##TP##_d == 1) s_unitString += std::string(#TP) + "^" + std::to_string(static_cast<long long>(t_##TP##_n)) + " "; else if(t_##TP##_n != 0) s_unitString += std::string(#TP) + "^(" + std::to_string(static_cast<long long>(t_##TP##_n)) + "/" + std::to_string(static_cast<long long>(t_##TP##_d)) + ") ";
 			ALL_UNITS(DIM_TO_STRING)
 #undef DIM_TO_STRING
 			

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -81,29 +81,34 @@ Tee_Test(test_scalar_rules) {
 }
 
 Tee_Test(test_divisor_rules) {
+	auto w = Mesi::RationalType<float, 1, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1>(2);
 	auto x = Mesi::Meters(3);
 	auto y = Mesi::Seconds(4);
 	auto z = Mesi::Kilos(5);
 
 	Tee_SubTest(test_dividing_scales_down) {
+		assert(static_cast<float>(w / 2) == 1.f);
 		assert(static_cast<float>(x / 2) == 1.5f);
 		assert(static_cast<float>(y / 2) == 2.f);
 		assert(static_cast<float>(z / 10) == 0.5f);
 	}
 
 	Tee_SubTest(test_dividing_matches_multiplying_by_the_inverse) {
+		assert(w / 2 == (1/2.f) * w);
 		assert(x / 2 == (1/2.f) * x);
 		assert(y / 3 == (1/3.f) * y);
 		assert(z / 10 == (1/10.f) * z);
 	}
 
 	Tee_SubTest(test_dividing_by_one_is_identity) {
+		assert(w / 1 == w);
 		assert(x / 1 == x);
 		assert(y / 1.0 == y);
 		assert(z / 1.0f == z);
 	}
 
 	Tee_SubTest(test_dividion_inverts_scaling) {
+		assert( (w / 2) * 2 == w);
 		assert( (x / 2) * 2 == x);
 		assert( (y / 7) * 7 == y);
 		assert( (z / 5) * 5 == z);
@@ -115,44 +120,53 @@ Tee_Test(type_info_tests) {
 		auto s = Mesi::Scalar(1);
 		auto m = Mesi::Meters(1);
 		auto m2 = Mesi::MetersSq(1);
+		auto m1_2 = Mesi::RationalType<float, 1, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1>(1);
 
 		auto mUnit = std::regex(R"(m |m$)");
 		auto m2Unit = std::regex(R"(m\^)");
+		auto m1_2Unit = std::regex(R"(m\^\([^)]*\))");
 
 		assert(s.getUnit().compare("") == 0);
 		assert(std::regex_search(m.getUnit(), mUnit));
 		assert(std::regex_search(m2.getUnit(), m2Unit));
+		assert(std::regex_search(m1_2.getUnit(), m1_2Unit));
 	}
 
 	Tee_SubTest(test_seconds_indicators_match_units) {
 		auto S = Mesi::Scalar(1);
 		auto s = Mesi::Seconds(1);
 		auto s2 = Mesi::SecondsSq(1);
+		auto s1_2 = Mesi::RationalType<float, 0, 1, 1, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1>(1);
 
 		auto sUnit = std::regex(R"(s |s$)");
 		auto s2Unit = std::regex(R"(s\^)");
+		auto s1_2Unit = std::regex(R"(s\^\([^)]*\))");
 
 		assert(S.getUnit().compare("") == 0);
 		assert(std::regex_search(s.getUnit(), sUnit));
 		assert(std::regex_search(s2.getUnit(), s2Unit));
+		assert(std::regex_search(s1_2.getUnit(), s1_2Unit));
 	}
 
 	Tee_SubTest(test_kilos_indicators_match_units) {
 		auto s = Mesi::Scalar(1);
 		auto kg = Mesi::Kilos(1);
 		auto kg2 = Mesi::KilosSq(1);
+		auto kg1_2 = Mesi::RationalType<float, 0, 1, 0, 1, 1, 2, 0, 1, 0, 1, 0, 1, 0, 1>(1);
 
 		auto kgUnit = std::regex(R"(kg |kg$)");
 		auto kg2Unit = std::regex(R"(kg\^)");
+		auto kg1_2Unit = std::regex(R"(kg\^\([^)]*\))");
 
 		assert(s.getUnit().compare("") == 0);
 		assert(std::regex_search(kg.getUnit(), kgUnit));
 		assert(std::regex_search(kg2.getUnit(), kg2Unit));
+		assert(std::regex_search(kg1_2.getUnit(), kg1_2Unit));
 	}
 
 	Tee_SubTest(test_all_unit_indicators_match_units) {
 		auto mskg = Mesi::Type<float, 1, 1, 1>(1).getUnit();
-		auto m2s2kg2 = Mesi::Type<float, 2, 2, 2>(1).getUnit();
+		auto m2s2kg2A1_2 = Mesi::RationalType<float, 2, 1, 2, 1, 2, 1, 1, 2, 0, 1, 0, 1, 0, 1>(1).getUnit();
 
 		auto mUnit = std::regex(R"(m |m$)");
 		auto m2Unit = std::regex(R"(m\^)");
@@ -160,14 +174,16 @@ Tee_Test(type_info_tests) {
 		auto s2Unit = std::regex(R"(s\^)");
 		auto kgUnit = std::regex(R"(kg |kg$)");
 		auto kg2Unit = std::regex(R"(kg\^)");
+		auto A1_2Unit = std::regex(R"(A\^\([^)]*\))");
 
 		assert(std::regex_search(mskg, mUnit));
 		assert(std::regex_search(mskg, sUnit));
 		assert(std::regex_search(mskg, kgUnit));
 
-		assert(std::regex_search(m2s2kg2, m2Unit));
-		assert(std::regex_search(m2s2kg2, s2Unit));
-		assert(std::regex_search(m2s2kg2, kg2Unit));
+		assert(std::regex_search(m2s2kg2A1_2, m2Unit));
+		assert(std::regex_search(m2s2kg2A1_2, s2Unit));
+		assert(std::regex_search(m2s2kg2A1_2, kg2Unit));
+		assert(std::regex_search(m2s2kg2A1_2, A1_2Unit));
 	}
 }
 
@@ -175,29 +191,32 @@ Tee_Test(test_multiplicative_behaviour) {
 		auto m = Mesi::Meters(2);
 		auto s = Mesi::Seconds(3);
 		auto kg = Mesi::Seconds(5);
-		auto mskg = m * s * kg;
+		auto A1_2 = Mesi::RationalType<float, 0, 1, 0, 1, 0, 1, 1, 2, 0, 1, 0, 1, 0, 1>(1);
+		auto mskgA1_2 = m * s * kg * A1_2;
 
 	Tee_SubTest(test_multiplying_values_consistent_with_floats) {
-		assert(static_cast<float>(mskg) == 30);
+		assert(static_cast<float>(mskgA1_2) == 30);
 	}
 
 	Tee_SubTest(test_multiplying_units_is_commutative) {
 		assert(m * s == s * m);
 		assert(s * kg == kg * s);
 		assert(kg * m == m * kg);
+		assert(kg * A1_2 == A1_2 * kg);
 	}
 
 	Tee_SubTest(test_multiplying_units_is_associative) {
 		assert((m * s) * kg == m * (s * kg));
+		assert((m * s) * A1_2 == m * (s * A1_2));
 	}
 
 	Tee_SubTest(test_inversion_multiplies_to_unity) {
-		assert((1 / mskg) * mskg == Mesi::Scalar(1));
-		assert(mskg / mskg == Mesi::Scalar(1));
+		assert((1 / mskgA1_2) * mskgA1_2 == Mesi::Scalar(1));
+		assert(mskgA1_2 / mskgA1_2 == Mesi::Scalar(1));
 	}
 
 	Tee_SubTest(test_inversion_methods_match) {
-		assert(1 / mskg == mskg / mskg / mskg);
+		assert(1 / mskgA1_2 == mskgA1_2 / mskgA1_2 / mskgA1_2);
 	}
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -307,8 +307,8 @@ Tee_Test(test_literal_overloads) {
 	assert(Mesi::SecondsSq(1) == 1_s2);
 	assert(Mesi::Kilos(1) == 1_kg);
 	assert(Mesi::KilosSq(1) == 1_kg2);
-	assert(Mesi::Newtons(1) == 1_N);
-	assert(Mesi::NewtonsSq(1) == 1_N2);
+	assert(Mesi::Newtons(1) == 1_n);
+	assert(Mesi::NewtonsSq(1) == 1_n2);
 }
 
 int main() {


### PR DESCRIPTION
- Add the remaining SI units and some derived units to the list
- Remove usage of reserved identifiers matching /^_[A-Z]/
- Add support for rational exponents