### PR TITLE
Rational powers of scaled units

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,16 @@ the source code.
 Advanced Usage
 --------------
 
-It is sometimes convenient to have non-integral exponents of units. This is
-available too, via `Mesi::RationalType`.
+It is sometimes convenient to define non-integral exponents of units directly.
+This is available too, via `Mesi::RationalType`.
 `RationalType` takes `std::ratio` arguments for its powers rather than integers.
 `RationalType` has all the features of the integral version (the integral
 version is in fact a simplified interface to the rational version).
+
+You can also use `Type::Pow` to raise a type to any rational power. This
+template expects a `std::ratio` type. `Mesi::Meters::Pow<std::ratio<2,1>>` are
+square meters, and `Mesi::Seconds::Pow<std::ratio<-1,2>>` are `s^(-1/2) =
+sqrt(Hz)`.
 
 `Type` and `RationalType` have three extra template arguments, `t_ratio`,
 `t_exponent_denominator`, and `t_power_of_ten`.

--- a/README.md
+++ b/README.md
@@ -148,16 +148,23 @@ available too, via `Mesi::RationalType`.
 `RationalType` has all the features of the integral version (the integral
 version is in fact a simplified interface to the rational version).
 
-`Type` and `RationalType` have two extra template arguments, `t_ratio` and
-`t_power_of_ten`.
-`t_power_of_ten` is used to create SI prefixes, but takes any integral value
+`Type` and `RationalType` have three extra template arguments, `t_ratio`,
+`t_exponent_denominator`, and `t_power_of_ten`.
+`t_ratio` and is used to create SI prefixes, but takes any  value
 happily.
 `t_ratio` expects a `std::ratio` type, and is also just a multiplier to the
 value. It can be used to make non-decimal scaled units, like minutes
-(`std::ratio<60,1>`) or fortnights, or imperial units.
+(`std::ratio<60,1>`) or fortnights, or imperial units.  `t_power_of_ten` also
+expects a `std::ratio` and is used to create SI prefixes, but will also take
+any other rational value.  `t_exponent_denominator` accepts any strictly
+positive integer value and can in special cases be used to create roots of
+scaling factors. Combining `t_ratio=std::ratio<2,1>`,
+`t_power_of_ten=std::ratio<3,1>`, `t_exponent_denominator=4` will result in an
+overall scaling factor of `2^(1/4) * 10^3`.
 You do not need to worry about simplifying the multiplier between `t_ratio` and
-`t_power_of_10`, as this is done for you, so long as you don't use
-`RationalTypeReduced` directly (which there is good no reason to do).
+`t_power_of_10` or calculating roots of `t_ratio`, as this is done for you, so
+long as you don't use `RationalTypeReduced` directly (which there is good no
+reason to do).
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ sqrt(Hz)`.
 
 `Type` and `RationalType` have three extra template arguments, `t_ratio`,
 `t_exponent_denominator`, and `t_power_of_ten`.
-`t_ratio` and is used to create SI prefixes, but takes any  value
-happily.
-`t_ratio` expects a `std::ratio` type, and is also just a multiplier to the
+`t_ratio` expects a `std::ratio` type, and is a multiplier to the
 value. It can be used to make non-decimal scaled units, like minutes
 (`std::ratio<60,1>`) or fortnights, or imperial units.  `t_power_of_ten` also
 expects a `std::ratio` and is used to create SI prefixes, but will also take

--- a/mesitype.h
+++ b/mesitype.h
@@ -9,108 +9,108 @@ namespace Mesi {
 		template<typename t_rat_1, intmax_t t_exp_den_1, typename t_po10_1, typename t_rat_2, intmax_t t_exp_den_2, typename t_po10_2>
 		struct ScalingSimplify
 		{
-        private:
-            struct Helper
-            {
-                template<intmax_t base, intmax_t pow>
-                struct Exp
-                {
-                    static_assert((pow == 0 || (std::numeric_limits<intmax_t>::max() / base / Exp<base, pow-1>::value) != 0), "pow must not overflow");
-                    static constexpr intmax_t value = base * Exp<base, pow-1>::value;
-                };
+		private:
+			struct Helper
+			{
+				template<intmax_t base, intmax_t pow>
+				struct Exp
+				{
+					static_assert((pow == 0 || (std::numeric_limits<intmax_t>::max() / base / Exp<base, pow-1>::value) != 0), "pow must not overflow");
+					static constexpr intmax_t value = base * Exp<base, pow-1>::value;
+				};
 
-                template<intmax_t base>
-                struct Exp<base, 0>
-                {
-                    static constexpr intmax_t value = 1;
-                };
+				template<intmax_t base>
+				struct Exp<base, 0>
+				{
+					static constexpr intmax_t value = 1;
+				};
 
-                template<intmax_t a, intmax_t b>
-                struct Mul
-                {
-                    static_assert(std::numeric_limits<intmax_t>::max() / a / b, "a*b must not overflow");
-                    static constexpr intmax_t value = a*b;
-                };
+				template<intmax_t a, intmax_t b>
+				struct Mul
+				{
+					static_assert(std::numeric_limits<intmax_t>::max() / a / b, "a*b must not overflow");
+					static constexpr intmax_t value = a*b;
+				};
 
-                using p_ratio = std::ratio<
-                    Mul<Exp<t_rat_1::num, t_exp_den_2>::value, Exp<t_rat_2::num, t_exp_den_1>::value>::value,
-                    Mul<Exp<t_rat_1::den, t_exp_den_2>::value, Exp<t_rat_2::den, t_exp_den_1>::value>::value>;
+				using p_ratio = std::ratio<
+					Mul<Exp<t_rat_1::num, t_exp_den_2>::value, Exp<t_rat_2::num, t_exp_den_1>::value>::value,
+					Mul<Exp<t_rat_1::den, t_exp_den_2>::value, Exp<t_rat_2::den, t_exp_den_1>::value>::value>;
 
-                constexpr Helper()
-                : p_num(p_ratio::num), p_den(p_ratio::den), p_power_of_ten(0), p_exp_den(t_exp_den_1 * t_exp_den_2)
-                {
-                    for(intmax_t d = 2; d < p_exp_den; d++)
-                    {
-                        while(p_exp_den % d == 0)
-                        {
-                            // This is a factor of the exponent's denominator, try to take the d-th root of numerator and denominator
-                            intmax_t rn = root(p_num, d);
-                            intmax_t rd = root(p_den, d);
-                            if(rn && rd)
-                            {
-                                // The d-th root of both is integer, so use these values going forward
-                                p_exp_den /= d;
-                                p_num = rn;
-                                p_den = rd;
-                            }
-                            else
-                            {
-                                // Can't take the d-th root, continue looking for other factors
-                                break;
-                            }
-                        }
-                    }
+				constexpr Helper()
+				: p_num(p_ratio::num), p_den(p_ratio::den), p_power_of_ten(0), p_exp_den(t_exp_den_1 * t_exp_den_2)
+				{
+					for(intmax_t d = 2; d < p_exp_den; d++)
+					{
+						while(p_exp_den % d == 0)
+						{
+							// This is a factor of the exponent's denominator, try to take the d-th root of numerator and denominator
+							intmax_t rn = root(p_num, d);
+							intmax_t rd = root(p_den, d);
+							if(rn && rd)
+							{
+								// The d-th root of both is integer, so use these values going forward
+								p_exp_den /= d;
+								p_num = rn;
+								p_den = rd;
+							}
+							else
+							{
+								// Can't take the d-th root, continue looking for other factors
+								break;
+							}
+						}
+					}
 
-                    while((p_num % 10) == 0)
-                    {
-                        p_num /= 10;
-                        p_power_of_ten++;
-                    }
-                    while((p_den % 10) == 0)
-                    {
-                        p_den /= 10;
-                        p_power_of_ten--;
-                    }
-                }
+					while((p_num % 10) == 0)
+					{
+						p_num /= 10;
+						p_power_of_ten++;
+					}
+					while((p_den % 10) == 0)
+					{
+						p_den /= 10;
+						p_power_of_ten--;
+					}
+				}
 
-                intmax_t p_num;
-                intmax_t p_den;
-                intmax_t p_power_of_ten;
-                intmax_t p_exp_den;
+				intmax_t p_num;
+				intmax_t p_den;
+				intmax_t p_power_of_ten;
+				intmax_t p_exp_den;
 
-                constexpr intmax_t root(intmax_t base, intmax_t r)
-                {
-                    intmax_t ret = 1;
-                    while(pow(ret, r) < base)
-                    {
-                        ret++;
-                    }
-                    if(pow(ret, r) == base)
-                    {
-                        return ret;
-                    }
-                    else
-                    {
-                        return 0;
-                    }
-                }
+				constexpr intmax_t root(intmax_t base, intmax_t r)
+				{
+					intmax_t ret = 1;
+					while(pow(ret, r) < base)
+					{
+						ret++;
+					}
+					if(pow(ret, r) == base)
+					{
+						return ret;
+					}
+					else
+					{
+						return 0;
+					}
+				}
 
-                constexpr intmax_t pow(intmax_t base, intmax_t exp)
-                {
-                    intmax_t ret = 1;
-                    while(exp > 0)
-                    {
-                        ret *= base;
-                        exp--;
-                    }
-                    return ret;
-                }
-            };
+				constexpr intmax_t pow(intmax_t base, intmax_t exp)
+				{
+					intmax_t ret = 1;
+					while(exp > 0)
+					{
+						ret *= base;
+						exp--;
+					}
+					return ret;
+				}
+			};
 
-        public:
-            using ratio = std::ratio<Helper().p_num, Helper().p_den>;
-            static constexpr intmax_t exponent_denominator = Helper().p_exp_den;
-            using power_of_ten = std::ratio_add<std::ratio_add<t_po10_1, t_po10_2>, std::ratio<Helper().p_power_of_ten, Helper().p_exp_den>>;
+		public:
+			using ratio = std::ratio<Helper().p_num, Helper().p_den>;
+			static constexpr intmax_t exponent_denominator = Helper().p_exp_den;
+			using power_of_ten = std::ratio_add<std::ratio_add<t_po10_1, t_po10_2>, std::ratio<Helper().p_power_of_ten, Helper().p_exp_den>>;
 		};
 	}
 /* Utility macro for applying another macro to all known units, for internal use only */
@@ -148,11 +148,11 @@ namespace Mesi {
 		typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
 	struct RationalTypeReduced
 	{
-        static constexpr intmax_t RN = t_ratio::num;
-        static constexpr intmax_t RD = t_ratio::den;
-        static constexpr intmax_t ED = t_exponent_denominator;
-        static constexpr intmax_t PN = t_power_of_ten::num;
-        static constexpr intmax_t PD = t_power_of_ten::den;
+		static constexpr intmax_t RN = t_ratio::num;
+		static constexpr intmax_t RD = t_ratio::den;
+		static constexpr intmax_t ED = t_exponent_denominator;
+		static constexpr intmax_t PN = t_power_of_ten::num;
+		static constexpr intmax_t PD = t_power_of_ten::den;
 		using BaseType = T;
 	private:
 		using Zero = std::ratio<0,1>;
@@ -162,9 +162,9 @@ namespace Mesi {
 
 		template<typename t_scale_ratio, intmax_t t_scale_10_to_the = 0>
 		using Scale = RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd,
-		      typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::ratio,
-		      _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::exponent_denominator,
-		      typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::power_of_ten>;
+			  typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::ratio,
+			  _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::exponent_denominator,
+			  typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, t_scale_ratio, 1, std::ratio<t_scale_10_to_the,1>>::power_of_ten>;
 
 		template<intmax_t t_scale>
 		using Multiply = Scale<std::ratio<t_scale, 1>>;
@@ -194,20 +194,20 @@ namespace Mesi {
 
 		template<typename t_ratio2, intmax_t t_exponent_denominator2, typename t_power_of_ten2>
 		explicit constexpr operator RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, t_ratio2, t_exponent_denominator2, t_power_of_ten2>() const {
-            using Scale = _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<t_ratio2::den, t_ratio2::num>, t_exponent_denominator2, std::ratio<-t_power_of_ten2::num, t_power_of_ten2::den>>;
+			using Scale = _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<t_ratio2::den, t_ratio2::num>, t_exponent_denominator2, std::ratio<-t_power_of_ten2::num, t_power_of_ten2::den>>;
 			T nv = val;
 
+			// TODO: Scale properly. Will need pow<T> for this if the exponent denominators require it...
 			static_assert(Scale::power_of_ten::den == 1, "Conversions only work if the powers of ten difference between scaling ratios is integral at the moment");
 			static_assert(Scale::exponent_denominator == 1, "Conversions only work for rational scaling at the moment");
 
 			nv *= Scale::ratio::num;
 			nv /= Scale::ratio::den;
 			for(intmax_t i = 0; i < Scale::power_of_ten::num; i++)
-                nv *= 10;
+				nv *= 10;
 			for(intmax_t i = 0; i > Scale::power_of_ten::num; i--)
-                nv /= 10;
+				nv /= 10;
 
-			// TODO: Scale properly. Will need pow<T> for this if the exponent denominators require it...
 			return RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, t_ratio2, t_exponent_denominator2, t_power_of_ten2>(nv);
 		}
 
@@ -224,14 +224,14 @@ namespace Mesi {
 				s_unitString += " * 10^";
 				if(t_power_of_ten::den != 1)
 				{
-                    s_unitString += "(";
+					s_unitString += "(";
 				}
 				s_unitString += std::to_string(static_cast<long long>(t_power_of_ten::num));
 				if(t_power_of_ten::den != 1)
 				{
-                    s_unitString += "/" + std::to_string(static_cast<long long>(t_power_of_ten::den));
+					s_unitString += "/" + std::to_string(static_cast<long long>(t_power_of_ten::den));
 				}
-                s_unitString += " ";
+				s_unitString += " ";
 			}
 
 #define DIM_TO_STRING(TP) if( t_##TP ::num == 1 && t_##TP ::den == 1 ) s_unitString += std::string(#TP) + " "; else if( t_##TP ::num != 0 && t_##TP ::den == 1) s_unitString += std::string(#TP) + "^" + std::to_string(static_cast<long long>(t_##TP ::num)) + " "; else if(t_##TP ::num != 0) s_unitString += std::string(#TP) + "^(" + std::to_string(static_cast<long long>(t_##TP ::num)) + "/" + std::to_string(static_cast<long long>(t_##TP ::den)) + ") ";
@@ -273,9 +273,9 @@ namespace Mesi {
 
 	template<typename T, typename t_m, typename t_s, typename t_kg, typename t_A, typename t_K, typename t_mol, typename t_cd, typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
 	using RationalType = RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd,
-        typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::ratio,
-        _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::exponent_denominator,
-        typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::power_of_ten>;
+		typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::ratio,
+		_internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::exponent_denominator,
+		typename _internal::ScalingSimplify<t_ratio, t_exponent_denominator, t_power_of_ten, std::ratio<1,1>, 1, std::ratio<0,1>>::power_of_ten>;
 
 #define TYPE_A_FULL_PARAMS typename t_m, typename t_s, typename t_kg, typename t_A, typename t_K, typename t_mol, typename t_cd, typename t_ratio, intmax_t t_ratio_exponent_denominator, typename t_power_of_ten
 #define TYPE_A_PARAMS t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, t_ratio, t_ratio_exponent_denominator, t_power_of_ten
@@ -305,7 +305,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-        using Scale = _internal::ScalingSimplify<t_ratio, t_ratio_exponent_denominator, t_power_of_ten, t_ratio2, t_ratio_exponent_denominator2, t_power_of_ten2>;
+		using Scale = _internal::ScalingSimplify<t_ratio, t_ratio_exponent_denominator, t_power_of_ten, t_ratio2, t_ratio_exponent_denominator2, t_power_of_ten2>;
 #define ADD_FRAC(TP) using TP = std::ratio_add<t_##TP, t_##TP##2>;
 		ALL_UNITS(ADD_FRAC)
 #undef ADD_FRAC
@@ -317,7 +317,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
 	) {
-        using Scale = _internal::ScalingSimplify<t_ratio, t_ratio_exponent_denominator, t_power_of_ten, std::ratio<t_ratio2::den, t_ratio2::num>, t_ratio_exponent_denominator2, std::ratio<-t_power_of_ten2::num, t_power_of_ten2::den>>;
+		using Scale = _internal::ScalingSimplify<t_ratio, t_ratio_exponent_denominator, t_power_of_ten, std::ratio<t_ratio2::den, t_ratio2::num>, t_ratio_exponent_denominator2, std::ratio<-t_power_of_ten2::num, t_power_of_ten2::den>>;
 #define SUB_FRAC(TP) using TP = std::ratio_subtract<t_##TP, t_##TP##2>;
 		ALL_UNITS(SUB_FRAC)
 #undef SUB_FRAC

--- a/mesitype.h
+++ b/mesitype.h
@@ -148,11 +148,6 @@ namespace Mesi {
 		typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
 	struct RationalTypeReduced
 	{
-		static constexpr intmax_t RN = t_ratio::num;
-		static constexpr intmax_t RD = t_ratio::den;
-		static constexpr intmax_t ED = t_exponent_denominator;
-		static constexpr intmax_t PN = t_power_of_ten::num;
-		static constexpr intmax_t PD = t_power_of_ten::den;
 		using BaseType = T;
 	private:
 		using Zero = std::ratio<0,1>;

--- a/mesitype.h
+++ b/mesitype.h
@@ -39,7 +39,7 @@ namespace Mesi {
 			public:
 				static T value()
 				{
-					static T v = calculate_value();
+					constexpr T v = calculate_value();
 					return v;
 				}
 			};
@@ -57,7 +57,7 @@ namespace Mesi {
 			{
 				static T value()
 				{
-					static T v = T(r::num)/T(r::den);
+					constexpr T v = T(r::num)/T(r::den);
 					return v;
 				}
 			};

--- a/mesitype.h
+++ b/mesitype.h
@@ -88,24 +88,20 @@ namespace Mesi {
 		private:
 			struct Helper
 			{
-				template<intmax_t base, intmax_t pow>
-				struct Exp
-				{
-					static_assert((pow == 0 || (std::numeric_limits<intmax_t>::max() / base / Exp<base, pow-1>::value) != 0), "pow must not overflow");
-					static constexpr intmax_t value = base * Exp<base, pow-1>::value;
-				};
-
-				template<intmax_t base>
-				struct Exp<base, 0>
-				{
-					static constexpr intmax_t value = 1;
-				};
-
 				template<intmax_t a, intmax_t b>
 				struct Mul
 				{
 					static_assert(std::numeric_limits<intmax_t>::max() / a / b, "a*b must not overflow");
 					static constexpr intmax_t value = a*b;
+				};
+
+				template<intmax_t base, intmax_t pow>
+				struct Exp : public Mul<base, Exp<base, pow-1>::value> {};
+
+				template<intmax_t base>
+				struct Exp<base, 0>
+				{
+					static constexpr intmax_t value = 1;
 				};
 
 				using p_ratio = std::ratio<

--- a/mesitype.h
+++ b/mesitype.h
@@ -368,7 +368,7 @@ namespace Mesi {
 	};
 
 	template<typename T, typename t_m, typename t_s, typename t_kg, typename t_A, typename t_K, typename t_mol, typename t_cd, typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
-	using RationalType = RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, typename _internal::Scale<t_ratio, t_exponent_denominator, t_power_of_ten>>;
+	using RationalType = RationalTypeReduced<T, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, typename _internal::ScaleMultiply<typename _internal::Scale<t_ratio, t_exponent_denominator, t_power_of_ten>, _internal::ScaleOne>::Scale>;
 
 #define TYPE_A_FULL_PARAMS typename t_m, typename t_s, typename t_kg, typename t_A, typename t_K, typename t_mol, typename t_cd, typename t_scale
 #define TYPE_A_PARAMS t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, t_scale

--- a/mesitype.h
+++ b/mesitype.h
@@ -557,6 +557,12 @@ namespace Mesi {
 		return left > right || left == right;
 	}
 
+	template<typename t_pow_ratio, typename T, TYPE_A_FULL_PARAMS>
+	auto pow(RationalTypeReduced<T, TYPE_A_PARAMS> v)
+	{
+		return typename RationalTypeReduced<T, TYPE_A_PARAMS>::template Pow<t_pow_ratio>(std::pow(T(v.val), T(t_pow_ratio::num)/T(t_pow_ratio::den)));
+	}
+
 #undef TYPE_A_FULL_PARAMS
 #undef TYPE_A_PARAMS
 #undef TYPE_B_FULL_PARAMS

--- a/mesitype.h
+++ b/mesitype.h
@@ -622,7 +622,7 @@ namespace Mesi {
 	 */
 
 	template<typename T, intmax_t t_m, intmax_t t_s, intmax_t t_kg, intmax_t t_A=0, intmax_t t_K=0, intmax_t t_mol=0, intmax_t t_cd=0, typename t_ratio = std::ratio<1,1>, intmax_t t_exponent_denominator=1, typename t_power_of_ten = std::ratio<0,1>>
-	using Type = RationalType<T, std::ratio<t_m, 1>, std::ratio<t_s, 1>, std::ratio<t_kg, 1>, std::ratio<t_A, 1>, std::ratio<t_K, 1>, std::ratio<t_mol, 1>, std::ratio<t_cd, 1>, t_ratio, t_exponent_denominator, t_pref>;
+	using Type = RationalType<T, std::ratio<t_m, 1>, std::ratio<t_s, 1>, std::ratio<t_kg, 1>, std::ratio<t_A, 1>, std::ratio<t_K, 1>, std::ratio<t_mol, 1>, std::ratio<t_cd, 1>, t_ratio, t_exponent_denominator, t_power_of_ten>;
 
 #ifndef MESI_LITERAL_TYPE
 #	define MESI_LITERAL_TYPE float

--- a/mesitype.h
+++ b/mesitype.h
@@ -41,6 +41,7 @@ namespace Mesi {
 		template<typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
 		struct Scale
 		{
+			static_assert(t_exponent_denominator > 0);
 		private:
 			template<typename T, typename p>
 			struct PowerOfTenValue

--- a/mesitype.h
+++ b/mesitype.h
@@ -37,7 +37,7 @@ namespace Mesi {
 					return ret;
 				}
 			public:
-				static T value()
+				static constexpr T value()
 				{
 					constexpr T v = calculate_value();
 					return v;
@@ -55,7 +55,7 @@ namespace Mesi {
 			template<typename T, typename r>
 			struct RatioValue<T, r, 1>
 			{
-				static T value()
+				static constexpr T value()
 				{
 					constexpr T v = T(r::num)/T(r::den);
 					return v;

--- a/mesitype.h
+++ b/mesitype.h
@@ -41,7 +41,7 @@ namespace Mesi {
 		template<typename t_ratio, intmax_t t_exponent_denominator, typename t_power_of_ten>
 		struct Scale
 		{
-			static_assert(t_exponent_denominator > 0);
+			static_assert(t_exponent_denominator > 0, "The exponent denominator must be positive");
 		private:
 			template<typename T, typename p>
 			struct PowerOfTenValue

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -362,16 +362,16 @@ Tee_Test(test_unit_scaling) {
 	Tee_SubTest(test_scaling_helpers) {
 		using S1 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 1, std::ratio<0,1>, std::ratio<2,1>, 1, std::ratio<0, 1>>;
 		assert(S1::value<float> == 1);
-		
+
 		using S2 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 2, std::ratio<0,1>, std::ratio<1,2>, 2, std::ratio<0, 1>>;
 		assert(S2::value<float> == 0.5);
-		
+
 		using S3 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<1, 2>>;
 		assert(S3::value<float> == 10);
-		
+
 		using S4 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
 		assert(S4::value<float> == std::pow(10.f, 0.5f));
-		
+
 		using S5 = Mesi::_internal::ScalingSimplify<std::ratio<2,1>, 2, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
 		assert(S5::value<float> == std::pow(2.f, 0.5f));
 
@@ -387,6 +387,24 @@ Tee_Test(test_unit_scaling) {
 	Tee_SubTest(test_unit_scaling_uniqueness) {
 		assert((std::is_same<Scalar::Multiply<10>, Mesi::Scalar::ScaleByTenToThe<1>>::value));
 		assert((std::is_same<Scalar::Multiply<4>::Multiply<25>, Mesi::Scalar::ScaleByTenToThe<3>::ScaleByTenToThe<-1>>::value));
+	}
+}
+
+Tee_Test(test_unit_exponentiation) {
+	using Minutes = Mesi::Minutes;
+
+	Tee_SubTest(test_helper) {
+		using RootScale = Mesi::_internal::ScalingPower<std::ratio<6,1>, 1, std::ratio<1,1>, std::ratio<1,2>>;
+		assert(RootScale::ratio::num == 6);
+		assert(RootScale::ratio::den == 1);
+		assert(RootScale::exponent_denominator == 2);
+		assert(RootScale::power_of_ten::num == 1);
+		assert(RootScale::power_of_ten::den == 2);
+	}
+
+	Tee_SubTest(test_sqrt) {
+		using SqMin = Minutes::Pow<std::ratio<1,2>>;
+		assert((std::is_same<decltype(SqMin{}*SqMin{}), Minutes>::value));
 	}
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -82,7 +82,7 @@ Tee_Test(test_scalar_rules) {
 }
 
 Tee_Test(test_divisor_rules) {
-	auto w = Mesi::RationalType<float, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(2);
+	auto w = Mesi::RationalType<float, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(2);
 	auto x = Mesi::Meters(3);
 	auto y = Mesi::Seconds(4);
 	auto z = Mesi::Kilograms(5);
@@ -121,7 +121,7 @@ Tee_Test(type_info_tests) {
 		auto s = Mesi::Scalar(1);
 		auto m = Mesi::Meters(1);
 		auto m2 = Mesi::MetersSq(1);
-		auto m1_2 = Mesi::RationalType<float, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(1);
+		auto m1_2 = Mesi::RationalType<float, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(1);
 
 		auto mUnit = std::regex(R"(m |m$)");
 		auto m2Unit = std::regex(R"(m\^)");
@@ -137,7 +137,7 @@ Tee_Test(type_info_tests) {
 		auto S = Mesi::Scalar(1);
 		auto s = Mesi::Seconds(1);
 		auto s2 = Mesi::SecondsSq(1);
-		auto s1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(1);
+		auto s1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(1);
 
 		auto sUnit = std::regex(R"(s |s$)");
 		auto s2Unit = std::regex(R"(s\^)");
@@ -153,7 +153,7 @@ Tee_Test(type_info_tests) {
 		auto s = Mesi::Scalar(1);
 		auto kg = Mesi::Kilograms(1);
 		auto kg2 = Mesi::KilogramsSq(1);
-		auto kg1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(1);
+		auto kg1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(1);
 
 		auto kgUnit = std::regex(R"(kg |kg$)");
 		auto kg2Unit = std::regex(R"(kg\^)");
@@ -167,7 +167,7 @@ Tee_Test(type_info_tests) {
 
 	Tee_SubTest(test_all_unit_indicators_match_units) {
 		auto mskg = Mesi::Type<float, 1, 1, 1>(1).getUnit();
-		auto m2s2kg2A1_2 = Mesi::RationalType<float, std::ratio<2, 1>, std::ratio<2, 1>, std::ratio<2, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(1).getUnit();
+		auto m2s2kg2A1_2 = Mesi::RationalType<float, std::ratio<2, 1>, std::ratio<2, 1>, std::ratio<2, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(1).getUnit();
 
 		auto mUnit = std::regex(R"(m |m$)");
 		auto m2Unit = std::regex(R"(m\^)");
@@ -192,7 +192,7 @@ Tee_Test(test_multiplicative_behaviour) {
 		auto m = Mesi::Meters(2);
 		auto s = Mesi::Seconds(3);
 		auto kg = Mesi::Seconds(5);
-		auto A1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 0>(1);
+		auto A1_2 = Mesi::RationalType<float, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<1, 2>, std::ratio<0, 1>, std::ratio<0, 1>, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0,1>>(1);
 		auto mskgA1_2 = m * s * kg * A1_2;
 
 	Tee_SubTest(test_multiplying_values_consistent_with_floats) {
@@ -342,7 +342,7 @@ Tee_Test(test_prefixes) {
 		assert((std::is_same<Mesi::Exa<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<18>>::value));
 		assert((std::is_same<Mesi::Zetta<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<21>>::value));
 		assert((std::is_same<Mesi::Yotta<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<24>>::value));
-		
+
 		assert((std::is_same<Mesi::Deci<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<-1>>::value));
 		assert((std::is_same<Mesi::Centi<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<-2>>::value));
 		assert((std::is_same<Mesi::Milli<Mesi::Scalar>, Mesi::Scalar::ScaleByTenToThe<-3>>::value));

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -10,7 +10,6 @@
 
 using namespace std;
 
-
 Tee_Test(test_basic_rules) {
 	auto x = Mesi::Meters(3);
 	auto y = Mesi::Meters(4);
@@ -400,18 +399,18 @@ Tee_Test(test_unit_exponentiation) {
 	using Minutes = Mesi::Minutes;
 
 	Tee_SubTest(test_helper) {
-		using RootScale = Mesi::_internal::ScalingPower<Mesi::_internal::Scale<std::ratio<6,1>, 1, std::ratio<1,1>>, std::ratio<1,2>>::Scale;
+		using RootScale = Mesi::_internal::ScalePower<Mesi::_internal::Scale<std::ratio<6,1>, 1, std::ratio<1,1>>, std::ratio<1,2>>::Scale;
 		assert(RootScale::ratio::num == 6);
 		assert(RootScale::ratio::den == 1);
 		assert(RootScale::exponent_denominator == 2);
 		assert(RootScale::power_of_ten::num == 1);
 		assert(RootScale::power_of_ten::den == 2);
 		
-		using ScalarScale = Mesi::_internal::ScalingPower<RootScale, std::ratio<2,1>>::Scale;
-		assert(ScalarScale::ratio::num == 1);
+		using ScalarScale = Mesi::_internal::ScalePower<RootScale, std::ratio<2,1>>::Scale;
+		assert(ScalarScale::ratio::num == 6);
 		assert(ScalarScale::ratio::den == 1);
 		assert(ScalarScale::exponent_denominator == 1);
-		assert(ScalarScale::power_of_ten::num == 0);
+		assert(ScalarScale::power_of_ten::num == 1);
 		assert(ScalarScale::power_of_ten::den == 1);
 	}
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -406,6 +406,13 @@ Tee_Test(test_unit_exponentiation) {
 		assert(RootScale::exponent_denominator == 2);
 		assert(RootScale::power_of_ten::num == 1);
 		assert(RootScale::power_of_ten::den == 2);
+		
+		using ScalarScale = Mesi::_internal::ScalingPower<RootScale, std::ratio<2,1>>::Scale;
+		assert(ScalarScale::ratio::num == 1);
+		assert(ScalarScale::ratio::den == 1);
+		assert(ScalarScale::exponent_denominator == 1);
+		assert(ScalarScale::power_of_ten::num == 0);
+		assert(ScalarScale::power_of_ten::den == 1);
 	}
 
 	Tee_SubTest(test_sqrt) {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -414,9 +414,18 @@ Tee_Test(test_unit_exponentiation) {
 		assert(ScalarScale::power_of_ten::den == 1);
 	}
 
-	Tee_SubTest(test_sqrt) {
+	Tee_SubTest(test_type_pow) {
 		using SqMin = Minutes::Pow<std::ratio<1,2>>;
 		assert((std::is_same<decltype(SqMin{}*SqMin{}), Minutes>::value));
+	}
+
+	Tee_SubTest(test_var_pow) {
+		Mesi::Minutes a = Mesi::Minutes(5);
+		auto b = Mesi::pow<std::ratio<2,1>>(a);
+		auto c = Mesi::pow<std::ratio<1,2>>(b);
+
+		assert(b == Mesi::Minutes(1)*Mesi::Minutes(1)*25);
+		assert(c == a);
 	}
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,11 +1,12 @@
-#include "../mesitype.h"
-#include "tee/tee.hpp"
-
+#include <cmath>
 #include <vector>
 #include <string>
 #include <tuple>
 #include <iostream>
 #include <regex>
+
+#include "../mesitype.h"
+#include "tee/tee.hpp"
 
 using namespace std;
 
@@ -358,6 +359,25 @@ Tee_Test(test_prefixes) {
 
 Tee_Test(test_unit_scaling) {
 	using Scalar = Mesi::Scalar;
+	Tee_SubTest(test_scaling_helpers) {
+		using S1 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 1, std::ratio<0,1>, std::ratio<2,1>, 1, std::ratio<0, 1>>;
+		assert(S1::value<float> == 1);
+		
+		using S2 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 2, std::ratio<0,1>, std::ratio<1,2>, 2, std::ratio<0, 1>>;
+		assert(S2::value<float> == 0.5);
+		
+		using S3 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<1, 2>>;
+		assert(S3::value<float> == 10);
+		
+		using S4 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
+		assert(S4::value<float> == std::pow(10.f, 0.5f));
+		
+		using S5 = Mesi::_internal::ScalingSimplify<std::ratio<2,1>, 2, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
+		assert(S5::value<float> == std::pow(2.f, 0.5f));
+
+		using S6 = Mesi::_internal::ScalingSimplify<std::ratio<2,1>, 2, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
+		assert(S6::value<float> == std::pow(20.f, 0.5f));
+	}
 	Tee_SubTest(test_unit_scaling_maths) {
 		assert((std::is_same<Scalar::Multiply<2>::Multiply<3>, Scalar::Multiply<6>>::value));
 		assert((std::is_same<Scalar::Multiply<2>::Divide<2>, Scalar>::value));

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -359,24 +359,30 @@ Tee_Test(test_prefixes) {
 
 Tee_Test(test_unit_scaling) {
 	using Scalar = Mesi::Scalar;
+	using namespace Mesi::_internal;
+	using Zero = std::ratio<0,1>;
+	using One = std::ratio<1,1>;
+	using Two = std::ratio<2,1>;
+	using OneHalf = std::ratio<1,2>;
+
 	Tee_SubTest(test_scaling_helpers) {
-		using S1 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 1, std::ratio<0,1>, std::ratio<2,1>, 1, std::ratio<0, 1>>;
-		assert(S1::value<float> == 1);
+		using S1 = ScaleMultiply<Scale<OneHalf, 1, Zero    >, Scale<Two,     1, Zero>   >::Scale;
+		assert(S1::value<float>() == 1);
 
-		using S2 = Mesi::_internal::ScalingSimplify<std::ratio<1,2>, 2, std::ratio<0,1>, std::ratio<1,2>, 2, std::ratio<0, 1>>;
-		assert(S2::value<float> == 0.5);
+		using S2 = ScaleMultiply<Scale<OneHalf, 2, Zero    >, Scale<OneHalf, 2, Zero>   >::Scale;
+		assert(S2::value<float>() == 0.5);
 
-		using S3 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<1, 2>>;
-		assert(S3::value<float> == 10);
+		using S3 = ScaleMultiply<Scale<One,     1, OneHalf >, Scale<One,     1, OneHalf>>::Scale;
+		assert(S3::value<float>() == 10);
 
-		using S4 = Mesi::_internal::ScalingSimplify<std::ratio<1,1>, 1, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
-		assert(S4::value<float> == std::pow(10.f, 0.5f));
+		using S4 = ScaleMultiply<Scale<One,     1, OneHalf >, Scale<One,     1, Zero   >>::Scale;
+		assert(S4::value<float>() == std::pow(10.f, 0.5f));
 
-		using S5 = Mesi::_internal::ScalingSimplify<std::ratio<2,1>, 2, std::ratio<0,1>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
-		assert(S5::value<float> == std::pow(2.f, 0.5f));
+		using S5 = ScaleMultiply<Scale<Two,     2, Zero    >, Scale<One,     1, Zero   >>::Scale;
+		assert(S5::value<float>() == std::pow(2.f, 0.5f));
 
-		using S6 = Mesi::_internal::ScalingSimplify<std::ratio<2,1>, 2, std::ratio<1,2>, std::ratio<1,1>, 1, std::ratio<0, 1>>;
-		assert(S6::value<float> == std::pow(20.f, 0.5f));
+		using S6 = ScaleMultiply<Scale<Two,     2, OneHalf >, Scale<One,     1, Zero   >>::Scale;
+		assert(S6::value<float>() == std::pow(20.f, 0.5f));
 	}
 	Tee_SubTest(test_unit_scaling_maths) {
 		assert((std::is_same<Scalar::Multiply<2>::Multiply<3>, Scalar::Multiply<6>>::value));
@@ -394,7 +400,7 @@ Tee_Test(test_unit_exponentiation) {
 	using Minutes = Mesi::Minutes;
 
 	Tee_SubTest(test_helper) {
-		using RootScale = Mesi::_internal::ScalingPower<std::ratio<6,1>, 1, std::ratio<1,1>, std::ratio<1,2>>;
+		using RootScale = Mesi::_internal::ScalingPower<Mesi::_internal::Scale<std::ratio<6,1>, 1, std::ratio<1,1>>, std::ratio<1,2>>::Scale;
 		assert(RootScale::ratio::num == 6);
 		assert(RootScale::ratio::den == 1);
 		assert(RootScale::exponent_denominator == 2);

--- a/tests/makefile
+++ b/tests/makefile
@@ -3,7 +3,7 @@
 TARGET=mesitype
 #CXX=g++
 
-C_FLAGS+= -std=c++14 --pedantic -w
+C_FLAGS+= -std=c++14 --pedantic -w -g
 
 SRC_FILES = $(shell find . -name '*.cpp' | grep -v tee)
 

--- a/tests/makefile
+++ b/tests/makefile
@@ -3,7 +3,7 @@
 TARGET=mesitype
 #CXX=g++
 
-C_FLAGS+= -std=c++14 --pedantic -w -g
+C_FLAGS+= -std=c++14 --pedantic -w
 
 SRC_FILES = $(shell find . -name '*.cpp' | grep -v tee)
 


### PR DESCRIPTION
- Move scaling information to a Scale template that keeps track of a scaling ratio and its exponent and a power of 10. The scale is (ratio)^(1/exponent) * 10^(power of ten), with ratio and power of ten being std::ratios and exponent an integer. Scale has an Inverse member type that inverts the scale.
- Use Scale is template parameter for Type instead of keeping the information separate
- Type gets a Pow<> template to get rational exponents of the type, i.e. Minute::Pow<std::ratio<1,2>> will be a Sqrt(Second) with a scaling of sqrt(60)
- Conversion operators between different scalings are fully supported (but not constexpr anymore, as pow(float)  is not constexpr)
