### PR TITLE
Add a TypeOperations template class

### DIFF
--- a/mesitype.h
+++ b/mesitype.h
@@ -267,6 +267,21 @@ namespace Mesi {
 /* Utility macro for applying another macro to all known units, for internal use only */
 #define ALL_UNITS(op) op(m) op(s) op(kg) op(A) op(K) op(mol) op(cd)
 
+	template<typename T>
+	struct TypeOperationsDefaults
+	{
+		using MultiplyResult = decltype(T{}*T{});
+		using DivideResult = decltype(T{}/T{});
+		using AddResult = decltype(T{}+T{});
+		using SubtractResult = decltype(T{}-T{});
+		using PowerResult = decltype(std::pow(T{},T{}));
+	};
+
+	template<typename T>
+	struct TypeOperations : public TypeOperationsDefaults<T>
+	{
+	};
+
 	/**
 	 * @brief Main class to store SI types
 	 *
@@ -349,6 +364,11 @@ namespace Mesi {
 		{}
 
 		constexpr RationalTypeReduced(RationalTypeReduced const& in)
+			:val(in.val)
+		{}
+
+		template<typename U>
+		constexpr RationalTypeReduced(RationalTypeReduced<U, t_m, t_s, t_kg, t_A, t_K, t_mol, t_cd, t_scale> const& in)
 			:val(in.val)
 		{}
 
@@ -464,7 +484,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val + right.val);
+		return RationalTypeReduced<typename TypeOperations<T>::AddResult, TYPE_A_PARAMS>(left.val + right.val);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS>
@@ -472,7 +492,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val - right.val);
+		return RationalTypeReduced<typename TypeOperations<T>::SubtractResult, TYPE_A_PARAMS>(left.val - right.val);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
@@ -484,7 +504,7 @@ namespace Mesi {
 #define ADD_FRAC(TP) using TP = std::ratio_add<t_##TP, t_##TP##2>;
 		ALL_UNITS(ADD_FRAC)
 #undef ADD_FRAC
-		return RationalTypeReduced<T, m, s, kg, A, K, mol, cd, Scale>(left.val * right.val);
+		return RationalTypeReduced<typename TypeOperations<T>::MultiplyResult, m, s, kg, A, K, mol, cd, Scale>(left.val * right.val);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
@@ -496,7 +516,7 @@ namespace Mesi {
 #define SUB_FRAC(TP) using TP = std::ratio_subtract<t_##TP, t_##TP##2>;
 		ALL_UNITS(SUB_FRAC)
 #undef SUB_FRAC
-		return RationalTypeReduced<T, m, s, kg, A, K, mol, cd, Scale>(left.val / right.val);
+		return RationalTypeReduced<typename TypeOperations<T>::DivideResult, m, s, kg, A, K, mol, cd, Scale>(left.val / right.val);
 	}
 
 	/*
@@ -526,7 +546,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val * right);
+		return RationalTypeReduced<typename TypeOperations<T>::MultiplyResult, TYPE_A_PARAMS>(left.val * right);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -542,7 +562,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
+		using Scalar = typename RationalTypeReduced<typename TypeOperations<T>::DivideResult, TYPE_A_PARAMS>::ScalarType;
 		return left / Scalar(T(right));
 	}
 

--- a/mesitype.h
+++ b/mesitype.h
@@ -267,18 +267,18 @@ namespace Mesi {
 /* Utility macro for applying another macro to all known units, for internal use only */
 #define ALL_UNITS(op) op(m) op(s) op(kg) op(A) op(K) op(mol) op(cd)
 
-	template<typename T>
+	template<typename T, typename U>
 	struct TypeOperationsDefaults
 	{
-		using MultiplyResult = decltype(T{}*T{});
-		using DivideResult = decltype(T{}/T{});
-		using AddResult = decltype(T{}+T{});
-		using SubtractResult = decltype(T{}-T{});
-		using PowerResult = decltype(std::pow(T{},T{}));
+		using MultiplyResult = decltype(T{}*U{});
+		using DivideResult = decltype(T{}/U{});
+		using AddResult = decltype(T{}+U{});
+		using SubtractResult = decltype(T{}-U{});
+		using PowerResult = decltype(std::pow(T{},U{}));
 	};
 
-	template<typename T>
-	struct TypeOperations : public TypeOperationsDefaults<T>
+	template<typename T, typename U>
+	struct TypeOperations : public TypeOperationsDefaults<T, U>
 	{
 	};
 
@@ -479,44 +479,44 @@ namespace Mesi {
 	/*
 	 * Arithmatic operators for combining SI values.
 	 */
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr auto operator+(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<typename TypeOperations<T>::AddResult, TYPE_A_PARAMS>(left.val + right.val);
+		return RationalTypeReduced<typename TypeOperations<T,U>::AddResult, TYPE_A_PARAMS>(left.val + right.val);
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr auto operator-(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
-		return RationalTypeReduced<typename TypeOperations<T>::SubtractResult, TYPE_A_PARAMS>(left.val - right.val);
+		return RationalTypeReduced<typename TypeOperations<T,U>::SubtractResult, TYPE_A_PARAMS>(left.val - right.val);
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
 	constexpr auto operator*(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_B_PARAMS> const& right
 	) {
 		using Scale = typename _internal::ScaleMultiply<t_scale, t_scale2>::Scale;
 #define ADD_FRAC(TP) using TP = std::ratio_add<t_##TP, t_##TP##2>;
 		ALL_UNITS(ADD_FRAC)
 #undef ADD_FRAC
-		return RationalTypeReduced<typename TypeOperations<T>::MultiplyResult, m, s, kg, A, K, mol, cd, Scale>(left.val * right.val);
+		return RationalTypeReduced<typename TypeOperations<T,U>::MultiplyResult, m, s, kg, A, K, mol, cd, Scale>(left.val * right.val);
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS, TYPE_B_FULL_PARAMS>
 	constexpr auto operator/(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_B_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_B_PARAMS> const& right
 	) {
 		using Scale = typename _internal::ScaleMultiply<t_scale, typename t_scale2::Inverse>::Scale;
 #define SUB_FRAC(TP) using TP = std::ratio_subtract<t_##TP, t_##TP##2>;
 		ALL_UNITS(SUB_FRAC)
 #undef SUB_FRAC
-		return RationalTypeReduced<typename TypeOperations<T>::DivideResult, m, s, kg, A, K, mol, cd, Scale>(left.val / right.val);
+		return RationalTypeReduced<typename TypeOperations<T,U>::DivideResult, m, s, kg, A, K, mol, cd, Scale>(left.val / right.val);
 	}
 
 	/*
@@ -546,7 +546,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<typename TypeOperations<T>::MultiplyResult, TYPE_A_PARAMS>(left.val * right);
+		return RationalTypeReduced<typename TypeOperations<T,S>::MultiplyResult, TYPE_A_PARAMS>(left.val * right);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -562,7 +562,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		using Scalar = typename RationalTypeReduced<typename TypeOperations<T>::DivideResult, TYPE_A_PARAMS>::ScalarType;
+		using Scalar = typename RationalTypeReduced<typename TypeOperations<T,S>::DivideResult, TYPE_A_PARAMS>::ScalarType;
 		return left / Scalar(T(right));
 	}
 

--- a/mesitype.h
+++ b/mesitype.h
@@ -546,7 +546,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<typename TypeOperations<T,S>::MultiplyResult, TYPE_A_PARAMS>(left.val * right);
+		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val * right);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -562,7 +562,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		using Scalar = typename RationalTypeReduced<typename TypeOperations<T,S>::DivideResult, TYPE_A_PARAMS>::ScalarType;
+		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
 		return left / Scalar(T(right));
 	}
 

--- a/mesitype.h
+++ b/mesitype.h
@@ -546,7 +546,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		return RationalTypeReduced<T, TYPE_A_PARAMS>(left.val * right);
+		return RationalTypeReduced<typename TypeOperations<T,S>::MultiplyResult, TYPE_A_PARAMS>(left.val * right);
 	}
 
 	template<typename T, TYPE_A_FULL_PARAMS, typename S>
@@ -562,7 +562,7 @@ namespace Mesi {
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
 		S const& right
 	) {
-		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
+		using Scalar = typename RationalTypeReduced<typename TypeOperations<T,S>::DivideResult, TYPE_A_PARAMS>::ScalarType;
 		return left / Scalar(T(right));
 	}
 
@@ -571,57 +571,57 @@ namespace Mesi {
 		S const & left,
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
 	) {
-		using Scalar = typename RationalTypeReduced<T, TYPE_A_PARAMS>::ScalarType;
+		using Scalar = typename RationalTypeReduced<typename TypeOperations<S,T>::DivideResult, TYPE_A_PARAMS>::ScalarType;
 		return Scalar(T(left)) / right;
 	}
 
 	/*
 	 * Comparison operators
 	 */
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator==(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return left.val == right.val;
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator<(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return left.val < right.val;
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator!=(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return !(right == left);
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator<=(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return left < right || left == right;
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator>(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return right < left;
 	}
 
-	template<typename T, TYPE_A_FULL_PARAMS>
+	template<typename T, typename U, TYPE_A_FULL_PARAMS>
 	constexpr bool operator>=(
 		RationalTypeReduced<T, TYPE_A_PARAMS> const& left,
-		RationalTypeReduced<T, TYPE_A_PARAMS> const& right
+		RationalTypeReduced<U, TYPE_A_PARAMS> const& right
 	) {
 		return left > right || left == right;
 	}


### PR DESCRIPTION
This allows users to specify the type of operations and has sane defaults that allow users to have storage types that change when e.g. multiplied, for example an 8.8 fixed point type. 8.8 x 8.8 fixed point multiplication has a 16.16 result.

Could possibly expand this to have template parameters for both types (left and right), to allow multiplication of e.g. 8.8 x 16.16